### PR TITLE
DragonBoard-410c: Describe Android is a third-party build

### DIFF
--- a/ConsumerEdition/DragonBoard-410c/Downloads/README.md
+++ b/ConsumerEdition/DragonBoard-410c/Downloads/README.md
@@ -7,7 +7,6 @@ The DragonBoard 410c comes pre-installed with Android (if purchased in a kit, OS
 ### Linaro supported operating systems
 
 - [Debian](Debian.md)
-- [Android](Android.md)
 - [OpenEmbedded](OpenEmbedded.md)
 
 ***
@@ -16,7 +15,8 @@ The DragonBoard 410c comes pre-installed with Android (if purchased in a kit, OS
 
 Other operating systems supported on DragonBoard 410c, offered by partners.
 
-- [Windows IoT Core](http://linaro.co/db41db410cwindowsgetstarted)
+- [Android](Android.md)
 - [Ubuntu Core](https://developer.ubuntu.com/en/snappy/start/dragonboard-410c/)
+- [Windows IoT Core](http://linaro.co/db41db410cwindowsgetstarted)
 
 ***


### PR DESCRIPTION
(and sort the third-party builds alphabetically)

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>