### PR TITLE
DB-410c: LinuxFastboot.md: reboot after flashing bootloader

### DIFF
--- a/ConsumerEdition/DragonBoard-410c/Installation/LinuxFastboot.md
+++ b/ConsumerEdition/DragonBoard-410c/Installation/LinuxFastboot.md
@@ -101,7 +101,14 @@ cd dragonboard410c_bootloader_emmc_linux-40
 $ ./flashall
 ```
 
-Now that the bootloader is setup, we will flash all remaining parts of the operating system. In order to do this we will be using the fastboot commands that are now readily available to us in our Terminal command line.
+The bootloader has now been flashed to the eMMC.  Rebooting will
+launch the newly-flashed boot loader, which will allow us to flash
+the remaining parts of the operating system.
+
+```shell
+# Reboot the system so we can flash the rest.
+$ sudo fastboot reboot
+```
 
 #### **Step 5**: Recall location of all downloaded files
 
@@ -114,7 +121,7 @@ Recall location of all downloaded files from the downloads page, files will be d
 ###### **Android**: Recall location of `boot.img.tar.xz`, `system.img.tar.xz`, `userdata.img.tar.xz`, `recovery.img.tar.xz`, `persist.img.tar.xz`, `cache.img.tar.xz`, downloaded from the downloads page
 - All of these files should have been downloaded from the downloads page
 
-#### **Step 6**: Unzip both all files
+#### **Step 6**: Unzip both files
 
 #### **Step 7**: Flash all images to the DragonBoard 410c
 
@@ -128,7 +135,7 @@ Recall location of all downloaded files from the downloads page, files will be d
 ```shell
 # (Once again) Check to make sure fastboot device connected
 $ sudo fastboot devices
-# It will show similar to bellow if the device is connected successfully
+# It will show similar to below if the device is connected successfully
 de82318	fastboot
 
 # cd to the directory the boot image and  were extracted


### PR DESCRIPTION
I found that I needed to reboot my DB410c after flashing the boot
loader, otherwise I could not successfully flash the root file
system.

Signed-off-by: Alex Elder <elder@linaro.org>