### PR TITLE
404 fixes for 96boards Documentation

### DIFF
--- a/ConsumerEdition/DragonBoard-410c/AdditionalDocs/Images/Images_Wiki/README.md
+++ b/ConsumerEdition/DragonBoard-410c/AdditionalDocs/Images/Images_Wiki/README.md
@@ -1,0 +1,1 @@
+# Wiki Images for DragonBoard-410c

--- a/ConsumerEdition/DragonBoard-410c/AdditionalDocs/Images/README.md
+++ b/ConsumerEdition/DragonBoard-410c/AdditionalDocs/Images/README.md
@@ -1,0 +1,3 @@
+[Images_Board](Images_Board/)
+[Images_HWUserManual](Images_HWUserManual/)
+[Images_Wiki](Images_Wiki/)

--- a/ConsumerEdition/DragonBoard-410c/HardwareDocs/HardwareUserManual.md
+++ b/ConsumerEdition/DragonBoard-410c/HardwareDocs/HardwareUserManual.md
@@ -83,7 +83,7 @@ redirect_from: /db410c-getting-started/HardwareDocs/HardwareUserManual.md/
 - [Special care when using USB](#special-care-when-using-usb)
 - [Statements regarding FCC](#statements-regarding-fcc)
 
-[Click Here](../AdditionalDocs/Images/Images_HWUserManual/) for access to raw images used in this doc.
+[Click Here](https://github.com/96boards/documentation/tree/master/ConsumerEdition/DragonBoard-410c/AdditionalDocs/Images) for access to raw images used in this doc.
 
 ***
 

--- a/ConsumerEdition/imx7-96/getting-started/README.md
+++ b/ConsumerEdition/imx7-96/getting-started/README.md
@@ -81,7 +81,7 @@ If you are already familiar with the i.MX7 96 board and would like to change out
 
 - [Downloads page](../downloads/): This page lists all Linaro and 3rd party operating systems available for i.MX7 96
 - [Installation page](../installation/): If you already have the images you need, this page has information on how to install the different operating systems onto your i.MX7 96 board
-- [Board Recovery](../installation/)
+- [Board Recovery](../installation/board-recovery.md.html)
    - If at any time your board is having unexplainable issues, it is suggested to attempt a board recovery. These instructions will guide you through a succesfull board recovery.
 - [Support](../support/)
    - From bug reports and current issues, to forum access and other useful resources, we want to help you find answers

--- a/ConsumerEdition/imx7-96/getting-started/README.md
+++ b/ConsumerEdition/imx7-96/getting-started/README.md
@@ -79,13 +79,13 @@ Follow instructions as outlined in the [i.MX7 96 Hardware User Manual](https://g
 
 If you are already familiar with the i.MX7 96 board and would like to change out the stock operating system, please proceed to one of the following pages:
 
-- [Downloads page](../downloads/README.md): This page lists all Linaro and 3rd party operating systems available for i.MX7 96
-- [Installation page](../installation/README.md): If you already have the images you need, this page has information on how to install the different operating systems onto your i.MX7 96 board
-- [Board Recovery](../installation/BoardRecovery.md)
+- [Downloads page](../downloads/): This page lists all Linaro and 3rd party operating systems available for i.MX7 96
+- [Installation page](../installation/): If you already have the images you need, this page has information on how to install the different operating systems onto your i.MX7 96 board
+- [Board Recovery](../installation/)
    - If at any time your board is having unexplainable issues, it is suggested to attempt a board recovery. These instructions will guide you through a succesfull board recovery.
-- [Support](../support/README.md)
+- [Support](../support/)
    - From bug reports and current issues, to forum access and other useful resources, we want to help you find answers
 
-Back to the [i.MX7 96 documentation home page](../README.md)
+Back to the [i.MX7 96 documentation home page](../)
 
 ***   

--- a/ConsumerEdition/imx7-96/guides/README.md
+++ b/ConsumerEdition/imx7-96/guides/README.md
@@ -1,3 +1,7 @@
+---
+title: Useful Guides for i.MX7 96
+permalink: /documentation/ConsumerEdition/imx7-96/guides/
+---
 # Useful Guides
 
 These guides will help to get you started with a variety of available on-boards software

--- a/ConsumerEdition/imx7-96/hardware-docs/README.md
+++ b/ConsumerEdition/imx7-96/hardware-docs/README.md
@@ -1,3 +1,7 @@
+---
+title: Hardware Documentation for i.MX7 96
+permalink: /documentation/ConsumerEdition/imx7-96/hardware-docs/
+---
 # Hardware Documentation
 
 Explore what makes your i.MX7-96 unique, technical specifications, schematics, hardware notes and more... This page allows you to see what is under the "i.MX7-96 hood" by offering static documentation published directly from the board vendors.

--- a/ConsumerEdition/imx7-96/hardware-docs/hardware-user-manual.md
+++ b/ConsumerEdition/imx7-96/hardware-docs/hardware-user-manual.md
@@ -1,3 +1,7 @@
+---
+title: Hardware User Manual for i.MX7 96
+permalink: /documentation/ConsumerEdition/imx7-96/hardware-docs/hardware-user-manual.md.html
+---
 # Board-X Development Board User Manual
 
 ### Table of Contents
@@ -113,7 +117,7 @@ The Board-X Development Board is a 96Boards compliant community board based on M
       -  2 -for radios (BT and WLAN activity)
 - **OS Support**:
    - Android 6.0
-- **Mechanical**: 
+- **Mechanical**:
    - Dimensions: 54mm by 85mm meeting 96Boards™ Consumer Edition standard dimensions specifications.
 - **Environmental**:
    - Operating Temp: -20°C to +45°C
@@ -213,16 +217,16 @@ Before you power up your Helio X20 Development Board for the first time you will
 
 < Add a list of HW/SW limitations (e.g. OTG and Type A USB can’t be use simultaneously) >
 
-#### Starting the board for the first time 
+#### Starting the board for the first time
 
 < Add a list of steps to switch ON the board for the first time including any warnings about jumper positions, connecting cables. A picture/block diagram showing how to connect the board for development is welcome >
 
-To start the board, follow these simple steps: 
+To start the board, follow these simple steps:
 
-1. Connect the HDMI cable to the Helio X20 Development Board connector (marked CON6501) and to the LCD Monitor. 
-2. Set the the third pin (USB HOST SET) of switch SW3205 to the position ON and connect the keyboard to USB connector marked CON6402 and the mouse to the USB connector marked CON6401. (It doesn’t matter which order you connect them in. ) 
+1. Connect the HDMI cable to the Helio X20 Development Board connector (marked CON6501) and to the LCD Monitor.
+2. Set the the third pin (USB HOST SET) of switch SW3205 to the position ON and connect the keyboard to USB connector marked CON6402 and the mouse to the USB connector marked CON6401. (It doesn’t matter which order you connect them in. )
 3. Plug the power supply into the power outlet.
-4. Press down the button (marked SW3201), and keep more than 3 seconds, the Android system will start. 
+4. Press down the button (marked SW3201), and keep more than 3 seconds, the Android system will start.
 
 > Note: If set the first pin (AUTO_BOOT_SET) of switch SW3205 to the position ON, the Android system will start automatically when the power supply is plugged into the power outlet.
 
@@ -243,7 +247,7 @@ MT6797 is a highly integrated application processor which uses an industry-leadi
 < A short section describing the properties of the PMIC and part of the schematic and description of what regulators power what components >
 
 - There are a PMIC and two dedicated DC - DC converters for MT6797 platform.
-- MT6351 is a power management system chip, containing 8 buck converters and 31 LDOs. 
+- MT6351 is a power management system chip, containing 8 buck converters and 31 LDOs.
 - DA9214 is a 4-phase high efficiency buck converter. It is applied to offer the kernel power of APU.
 
 FAN53555 is high efficiency step-down switching regulator. It is applied to offer the DVDD power of GPU.
@@ -303,14 +307,14 @@ The GPS implementation is based on MTK connectivity chip MT6631 (U5003) supporti
 
 < A short section describing the how the board satisfies this requirement and if there are limitations when a mezzanine display board is connected. It is highly recommended to provide a block diagram showing how the SoC, external connectors and intermediate drivers/convertors are wired up >
 
-### HDMI 
+### HDMI
 
 - The 96Boards specification calls for an HDMI port to be present on the board. The MT6797 doesn’t include a built-in HDMI interface.
-- The Helio X20 Development Board deploys the built-in DPI interface as the source for the HDMI output. A peripheral Bridge IC (U6502, MT8193) performs this task and it supports a resolution from 480i to 1080p at 30Hz. 
+- The Helio X20 Development Board deploys the built-in DPI interface as the source for the HDMI output. A peripheral Bridge IC (U6502, MT8193) performs this task and it supports a resolution from 480i to 1080p at 30Hz.
 
 ### MIPI-DSI
 
-- The 96Boards specification calls for a MIPI-DSI implementation via the High Speed Expansion Connector. 
+- The 96Boards specification calls for a MIPI-DSI implementation via the High Speed Expansion Connector.
 - The Helio X20 Development Board implements a 4-lane MIPI_DSI interface meeting this requirement. It can support up to FHD(1080p@60fps). The Helio X20 Development Board routes the MIPI_DSI interface signals to the DSI-0 interface of the MT6797.
 
 ### Camera Interface
@@ -318,13 +322,13 @@ The GPS implementation is based on MTK connectivity chip MT6631 (U5003) supporti
 < A short section describing if the board satisfies this requirement and how. It is highly recommended to provide a block diagram showing how the SoC, external connectors and intermediate drivers/convertors are wired up >
 
 - The 96Boards specification calls for two camera interfaces.
-- The Helio X20 Development Board supports two camera interfaces, one with a 4-lane MIPI_CSI interface and one with 2-lane MIPI_CSI interface, meeting this requirement. The 4-lane MIPI_CSI interface can support 25M camera and the 2-lane MIPI_CSI interface can support 8M camera. 
+- The Helio X20 Development Board supports two camera interfaces, one with a 4-lane MIPI_CSI interface and one with 2-lane MIPI_CSI interface, meeting this requirement. The 4-lane MIPI_CSI interface can support 25M camera and the 2-lane MIPI_CSI interface can support 8M camera.
 
 ### USB Ports
 
 < A short section describing the how the board satisfies these requirements, the type of ports available and if there are limitations e.g. host and slave ports can’t be used simultaneously >
 
-The Helio X20 Development Board supports a USB device port and three USB host ports via a USB MUX(U6503). The input channel( D+/D-) of USB MUX is connected to the P0 port of the SOC MT6797, and the two output channels(1D+/1D-,2D+/2D-) are connected to micro USB port and USB hub respectively. The three USB host ports are connected to the downstream ports of the USB hub.The control of U6503 is done via a software controlled GPIO (USB_SW_SEL, EINT9 from the SOC MT6797). When this signal is logic low, ‘0’, the USB data lines are routed to the Micro USB connector and the MT6797 P0 port is set to device mode. When ‘USB_SW_SEL’ is logic level high, ‘1’, the USB data lines are routed to U6401 (a 3-port USB HUB) and the MT6797 P0 port is set to host mode. The user can overwrite the software control by sliding switch 3 of dip-switch SW3205 to the ‘ON’ position. That action forces the USB–MUX (U6503) to route the USB data lines to the USB HUB. The overwrite option exists for the host mode only, you cannot hardware overwrite the MUX to force device mode. 
+The Helio X20 Development Board supports a USB device port and three USB host ports via a USB MUX(U6503). The input channel( D+/D-) of USB MUX is connected to the P0 port of the SOC MT6797, and the two output channels(1D+/1D-,2D+/2D-) are connected to micro USB port and USB hub respectively. The three USB host ports are connected to the downstream ports of the USB hub.The control of U6503 is done via a software controlled GPIO (USB_SW_SEL, EINT9 from the SOC MT6797). When this signal is logic low, ‘0’, the USB data lines are routed to the Micro USB connector and the MT6797 P0 port is set to device mode. When ‘USB_SW_SEL’ is logic level high, ‘1’, the USB data lines are routed to U6401 (a 3-port USB HUB) and the MT6797 P0 port is set to host mode. The user can overwrite the software control by sliding switch 3 of dip-switch SW3205 to the ‘ON’ position. That action forces the USB–MUX (U6503) to route the USB data lines to the USB HUB. The overwrite option exists for the host mode only, you cannot hardware overwrite the MUX to force device mode.
 
 < Please send any images to robert.wolff@linaro.org >
 
@@ -337,8 +341,8 @@ The Helio X20 Development Board supports a USB device port and three USB host po
 The Helio X20 Development Board supports three USB host port via a USB2.0 hub (U6401 USB2513-AEZG). Its upstream signal is connected to USB_P0 interface of MT6797.
 
 - Port 1 of the USB HUB is routed to CON6401, a Type ‘A’ USB Host connector. A current limited controller (U6402) sets the Power Current limit to 1.18A.  
-- Port 2 of the USB HUB is routed to CON6402, a Type ‘A’ USB Host connector. A current limited controller (U6403) sets the Power Current limit to 1.18A. 
-- Port 3 of the USB HUB is routed to the High Speed Expansion connector. No current limited controller is implemented on the board for this channel. 
+- Port 2 of the USB HUB is routed to CON6402, a Type ‘A’ USB Host connector. A current limited controller (U6403) sets the Power Current limit to 1.18A.
+- Port 3 of the USB HUB is routed to the High Speed Expansion connector. No current limited controller is implemented on the board for this channel.
 
 ### USB Device ports
 
@@ -346,7 +350,7 @@ The Helio X20 Development Board supports three USB host port via a USB2.0 hub (U
 
 The Helio X20 Development Board implements a device port. The port is located at CON6403, a Micro USB type B. It is routed to USB_P0 interface of MT6797.
 
-> Note: the board can work in one mode at a time, Host mode or Device mode, not both. 
+> Note: the board can work in one mode at a time, Host mode or Device mode, not both.
 
 ### Audio
 
@@ -360,7 +364,7 @@ The Helio X20 Development Board has four audio ports: BT, HDMI, PCM and analog p
 
 The Helio X20 Development Board can be powered by two ways:
 
-- 8V to 18V supply from a dedicated DC jack(J901) 
+- 8V to 18V supply from a dedicated DC jack(J901)
 - 8V to 18V supply from the DC_IN pins on the Low Speed Expansion Connector(CON7001)
 
 ### Power Measurement
@@ -393,11 +397,11 @@ The Helio X20 Development Board has two UART ports (UART1 / UART0), both present
 
 The Helio X20 Development Board presents four buttons. They are Power key,VOL up key,VOL down key and Reset key. The power ON/OFF and RESET signals are also routed to the Low Speed Expansion connector.
 
-#### Power Button 
+#### Power Button
 
 < Example >
 
-The push-button SW3201 serves as the power-on/sleep button. Upon applying power to the board, press the power button for more than 3 seconds, the board will boot up. Once the board is running you can turn power-off by pressing the power button for more than 3 seconds. If the board is in a sleep mode, pressing the power bottom will wake up the board. Oppositely, if the board is in an active mode, pressing the power bottom will change the board into sleep mode. 
+The push-button SW3201 serves as the power-on/sleep button. Upon applying power to the board, press the power button for more than 3 seconds, the board will boot up. Once the board is running you can turn power-off by pressing the power button for more than 3 seconds. If the board is in a sleep mode, pressing the power bottom will wake up the board. Oppositely, if the board is in an active mode, pressing the power bottom will change the board into sleep mode.
 
 #### Reset Button
 
@@ -409,13 +413,13 @@ The push-button SW3204 serves as the hardware reset button. press the button for
 
 < Example >
 
-The Volume UP button is used to control the output speaker volume of the Helio X20 Development Board. 
+The Volume UP button is used to control the output speaker volume of the Helio X20 Development Board.
 
 #### Volume down
 
 < Example >
 
-The Volume Down button is used to control the output speaker volume of the Helio X20 Development Board. 
+The Volume Down button is used to control the output speaker volume of the Helio X20 Development Board.
 
 ### LED Indicators
 
@@ -427,8 +431,8 @@ The Helio X20 Development Board has six LEDs.
 
 < Example >
 
-- WiFi activity LED –The Helio X20 Development Board drives this Yellow LED via BPI_BUS12, an IO from MT6797. 
-- BT activity LED –The Helio X20 Development Board drives this Blue LED via BPI_BUS13, an IO from MT6797. 
+- WiFi activity LED –The Helio X20 Development Board drives this Yellow LED via BPI_BUS12, an IO from MT6797.
+- BT activity LED –The Helio X20 Development Board drives this Blue LED via BPI_BUS13, an IO from MT6797.
 
 #### Four User LEDs
 
@@ -475,80 +479,80 @@ The Helio X20 Development Board also has a additional interface (CON9001)for use
 |    SYS_5V           |     +5V           |   37  |   38  |    SYC_DCIN        |    DC_IN            |
 |    GND              |     GND           |   39  |   40  |    GND             |    GND              |
 
-### UART {0/1} 
+### UART {0/1}
 
 < Example >
 
-- The 96Boards specifications calls for a 4-wire UART implementation, UART0 and an optimal second 2-wire UART, UART1 on the Low Speed Expansion Connector. 
-- The Helio X20 Development Board implements UART0 as a 4-wire UART that connects directly to the MT6797 SoC. These signals are driven at 1.8V. 
-- The Helio X20 Development Board implements UART1 as a 2-wire UART that connects directly to the MT6797 SoC. These signals are driven at 1.8V. 
+- The 96Boards specifications calls for a 4-wire UART implementation, UART0 and an optimal second 2-wire UART, UART1 on the Low Speed Expansion Connector.
+- The Helio X20 Development Board implements UART0 as a 4-wire UART that connects directly to the MT6797 SoC. These signals are driven at 1.8V.
+- The Helio X20 Development Board implements UART1 as a 2-wire UART that connects directly to the MT6797 SoC. These signals are driven at 1.8V.
 
-### I2C {0/1} 
+### I2C {0/1}
 
 < Example >
 
-- The 96Boards specification calls for two I2C interfaces to be implemented on the Low Speed Expansion Connector. 
+- The 96Boards specification calls for two I2C interfaces to be implemented on the Low Speed Expansion Connector.
 - The Helio X20 Development Board implements both interfaces named I2C4 and I2C5. They connect directly to the MT6797 SoC. Each of the I2C lines is pulled up to VIO18_PMU via 4.7K resistor.
 
-### GPIO {A-L} 
+### GPIO {A-L}
 
 < Example >
 
-The 96Boards specification calls for 12 GPIO lines to be implemented on the Low Speed Expansion Connector. Some of these GPIOs may support alternate functions for DSI/CSI control 
+The 96Boards specification calls for 12 GPIO lines to be implemented on the Low Speed Expansion Connector. Some of these GPIOs may support alternate functions for DSI/CSI control
 
-The Helio X20 board implements this requirement. All GPIOs are routed to the MT6797 SoC. 
+The Helio X20 board implements this requirement. All GPIOs are routed to the MT6797 SoC.
 
 - GPIO A -Connects to EINT16 of MT6797 SoC, can serves as external interrupt supporting the 96Boards requirements to create a wake-up event for the SoC. It is a 1.8V signal.
-- GPIO B -Connects to EINT5 of MT6797 SoC, can serves as external interrupt supporting the 96Boards requirements to create a wake-up event for the SoC. It is a 1.8V signal. 
-- GPIO C -Connects to EINT4 of MT6797 SoC, can serves as external interrupt supporting the 96Boards requirements to create a wake-up event for the SoC. It is a 1.8V signal. 
+- GPIO B -Connects to EINT5 of MT6797 SoC, can serves as external interrupt supporting the 96Boards requirements to create a wake-up event for the SoC. It is a 1.8V signal.
+- GPIO C -Connects to EINT4 of MT6797 SoC, can serves as external interrupt supporting the 96Boards requirements to create a wake-up event for the SoC. It is a 1.8V signal.
 - GPIO D -Connects to EINT3 of MT6797 SoC, can serves as external interrupt supporting the 96Boards requirements to create a wake-up event for the SoC. It is a 1.8V signal.  
-- GPIO E -Connects to EINT2 of MT6797 SoC, can serves as external interrupt supporting the 96Boards requirements to create a wake-up event for the SoC. It is a 1.8V signal. 
-- GPIO F -Connects to EINT1 of MT6797 SoC, can serves as external interrupt supporting the 96Boards requirements to create a wake-up event for the SoC. It is a 1.8V signal. 
-- GPIO G -Connects to DSI_TE of MT6797 SoC, can serves as DSI_TE or GPIO179. It is a 1.8V signal. 
-- GPIO H -Connects to LCM_RST of MT6797 SoC, can serves as LCM_RST or GPIO180. It is a 1.8V signal. 
-- GPIO I -Connects to CAM_RST0 of MT6797 SoC, can serves as CAM_RST0 or GPIO32. It is a 1.8V signal. 
-- GPIO J -Connects to CAM_PDN0 of MT6797 SoC, can serves as CAM_PDN0 or GPIO28. It is a 1.8V signal. 
-- GPIO K -Connects to CAM_RST1 of MT6797 SoC, can serves as CAM_RST1 or GPIO33. It is a 1.8V signal. 
-- GPIO L -Connects to CAM_PDN1 of MT6797 SoC, can serves as CAM_PDN1 or GPIO29. It is a 1.8V signal. 
+- GPIO E -Connects to EINT2 of MT6797 SoC, can serves as external interrupt supporting the 96Boards requirements to create a wake-up event for the SoC. It is a 1.8V signal.
+- GPIO F -Connects to EINT1 of MT6797 SoC, can serves as external interrupt supporting the 96Boards requirements to create a wake-up event for the SoC. It is a 1.8V signal.
+- GPIO G -Connects to DSI_TE of MT6797 SoC, can serves as DSI_TE or GPIO179. It is a 1.8V signal.
+- GPIO H -Connects to LCM_RST of MT6797 SoC, can serves as LCM_RST or GPIO180. It is a 1.8V signal.
+- GPIO I -Connects to CAM_RST0 of MT6797 SoC, can serves as CAM_RST0 or GPIO32. It is a 1.8V signal.
+- GPIO J -Connects to CAM_PDN0 of MT6797 SoC, can serves as CAM_PDN0 or GPIO28. It is a 1.8V signal.
+- GPIO K -Connects to CAM_RST1 of MT6797 SoC, can serves as CAM_RST1 or GPIO33. It is a 1.8V signal.
+- GPIO L -Connects to CAM_PDN1 of MT6797 SoC, can serves as CAM_PDN1 or GPIO29. It is a 1.8V signal.
 
-### SPI 0 
+### SPI 0
 
 < Example >
 
-- The 96Boards specification calls for one SPI bus master to be provided on the Low Speed Expansion Connector. 
-- The Helio X20 Development Board implements a full SPI master with 4 wires, CLK, CS, MOSI and MISO. The signals are connected directly to the MT6797 SoC and driven at 1.8V. 
+- The 96Boards specification calls for one SPI bus master to be provided on the Low Speed Expansion Connector.
+- The Helio X20 Development Board implements a full SPI master with 4 wires, CLK, CS, MOSI and MISO. The signals are connected directly to the MT6797 SoC and driven at 1.8V.
 
 ### PCM/I2S
 
 < Example >
 
-- The 96Boards specification calls for one PCM/I2S bus to be provided on the Low Speed Expansion Connector. The CLK, FS and DO signals are required while the DI is optional. 
+- The 96Boards specification calls for one PCM/I2S bus to be provided on the Low Speed Expansion Connector. The CLK, FS and DO signals are required while the DI is optional.
 - The Helio X20 Development Board implements a PCM/I2S interface with 4 wires, CLK, FS, DO and DI. The signals are connected directly to the MT6797 SoC and driven at 1.8V.  
 
-### Power and Reset 
+### Power and Reset
 
 < Example >
 
-- The 96Boards specification calls for a signal on the Low Speed Expansion Connector that can power on/off the board and a signal that serves as a board reset signal. 
-- The Helio X20 Development Board routes the PWR_BTN_N (named PWRKEY on schematic) signal to the PWRKEY pin of the PMIC MT6351. This signal is driven by SW3201 as well, the on-board power on push-button switch.  A mezzanine implementation of this signals should not drive it with any voltage, the only allowed operation is to force it to GND to start the board from a sleep mode. 
+- The 96Boards specification calls for a signal on the Low Speed Expansion Connector that can power on/off the board and a signal that serves as a board reset signal.
+- The Helio X20 Development Board routes the PWR_BTN_N (named PWRKEY on schematic) signal to the PWRKEY pin of the PMIC MT6351. This signal is driven by SW3201 as well, the on-board power on push-button switch.  A mezzanine implementation of this signals should not drive it with any voltage, the only allowed operation is to force it to GND to start the board from a sleep mode.
 - The Helio X20 Development Board routes the RST_BTN_N (named SYSRSTB on schematic) signal to the SYSRSTB pin of the PMIC MT6351.
 
 
-### Power Supplies 
+### Power Supplies
 
 < Example >
 
-The 96Boards specification calls for three power rails to be present on the Low Speed Expansion Connector: 
-- +1.8V  Max of 100mA 
-- +5V  Provide a minimum of 5W of power (1A). 
+The 96Boards specification calls for three power rails to be present on the Low Speed Expansion Connector:
+- +1.8V  Max of 100mA
+- +5V  Provide a minimum of 5W of power (1A).
 
-SYS_DCIN  8-18V input with enough current to support all the board functions or the output DCIN from on-board DC Connector able to provide a minimum of 7W of power. 
+SYS_DCIN  8-18V input with enough current to support all the board functions or the output DCIN from on-board DC Connector able to provide a minimum of 7W of power.
 
-The Helio X20 Development Board supports these requirements as follows: 
+The Helio X20 Development Board supports these requirements as follows:
 - +1.8V  Driven by PMIC MT6351 up to  1000mA.  It is the system IO power (VIO18_PMU), and it can supply power up to 200mA to the Low Speed Expansion Connector.
 - +5V  Driven by a 6A DC-DC buck converter (U901). It also provides the VBUS power to the two USB host connectors (CON6401, CON6402) and the HDMI 5V power to the HDMI connector (CON6501).The remaining capacity provides a max current of 2A to the Low Speed Expansion Connector, for a total of 10W which meets the 96Boards requirements.
- 
-SYS_DCIN  Can serves as the board’s main power source or can receive power from the board. 
+
+SYS_DCIN  Can serves as the board’s main power source or can receive power from the board.
 
 [Back to top]()
 
@@ -591,57 +595,57 @@ SYS_DCIN  Can serves as the board’s main power source or can receive power fro
 |   NC               |   HSIC_STR           |   57  |   58  |   GND              |   GND                                     |
 |   NC               |   HSIC_DATA          |   59  |   60  |   RESERVED         |   Pull-up  to VIO18_PMU<br>via 100K resistor |
 
-### MIPI DSI 0 
+### MIPI DSI 0
 
 < Example >
 
-- The 96Boards specification calls for a MIPI-DSI to be present on the High Speed Expansion Connector. A minimum of one lane is required and up to four lanes can be accommodated on the connector. 
-- The Helio X20 Development Board implementation supports a full four lane (1.2Gbps/lane) MIPI-DSI interface that is routed to the High Speed Expansion Connector. The MIPI-DSI signals are directly connected to DSI-0 of MT6797. 
+- The 96Boards specification calls for a MIPI-DSI to be present on the High Speed Expansion Connector. A minimum of one lane is required and up to four lanes can be accommodated on the connector.
+- The Helio X20 Development Board implementation supports a full four lane (1.2Gbps/lane) MIPI-DSI interface that is routed to the High Speed Expansion Connector. The MIPI-DSI signals are directly connected to DSI-0 of MT6797.
 
-### MIPI CSI {0/1} 
+### MIPI CSI {0/1}
 
 < Example >
 
-- The 96Boards specification calls for two MIPI-CSI interfaces to be present on the High Speed Expansion Connector. Both interfaces are optional. CSI0 interface can be up to four lanes while CSI1 is up to two lanes. 
+- The 96Boards specification calls for two MIPI-CSI interfaces to be present on the High Speed Expansion Connector. Both interfaces are optional. CSI0 interface can be up to four lanes while CSI1 is up to two lanes.
 - The Helio X20 Development Board implementation supports a full four lane MIPI-CSI interface on CSI0 and two lanes of MIPI-CSI on CSI1. All MIPI-CSI signals are routed directly to/from the MT6797SoC.  CSI0 can support up to 25M@30fps and CSI1 can support up to 8M@30fps. The max data rate of each lane is 2.5Gbps.
 
 
-### I2C {2/3} 
+### I2C {2/3}
 
 < Example >
 
-- The 96Boards specification calls for two I2C interfaces to be present on the High Speed Expansion Connector. Both interfaces are optional unless a MIPI-CSI interface has been implemented. Then an I2C interface shall be implemented. 
+- The 96Boards specification calls for two I2C interfaces to be present on the High Speed Expansion Connector. Both interfaces are optional unless a MIPI-CSI interface has been implemented. Then an I2C interface shall be implemented.
 - The Helio X20 Development Board implementation supports two MIPI-CSI interfaces and therefore must support two I2C interfaces. For MIPI-CSI0 the companion I2C2 is routed directly from the MT6797SoC. For MIPI-CSI1, the companion I2C is I2C3. Each of the I2C lines is pulled up to VIO18_PMU via 4.7K resistor.
 
-### SD/SPI 
+### SD/SPI
 
 < Example >
 
-- The 96Boards specification calls for an SD interface or a SPI port to be part of the High Speed Expansion Connector. 
-- The Helio X20 Development Board implements a full SPI master with 4 wires (96Boards SPI Configuration), CLK, CS, MOSI and MISO. All the signals are connected directly to the MT6797 SoC. These signals are driven at 1.8V. 
+- The 96Boards specification calls for an SD interface or a SPI port to be part of the High Speed Expansion Connector.
+- The Helio X20 Development Board implements a full SPI master with 4 wires (96Boards SPI Configuration), CLK, CS, MOSI and MISO. All the signals are connected directly to the MT6797 SoC. These signals are driven at 1.8V.
 
-### Clocks 
+### Clocks
 
 < Example >
 
-- The 96Boards specification calls for one or two programmable clock interfaces to be provided on the High Speed Expansion Connector. These clocks may have a secondary function of being CSI0_MCLK and CSI1_MCLK. If these clocks can’t be supported by the SoC than an alternative GPIO or No-Connect is allowed by the specifications. 
-- The Helio X20 Development Board implements two CSI clocks which are connected directly to the MT6797 SoC. These signals are driven at 1.8V. 
+- The 96Boards specification calls for one or two programmable clock interfaces to be provided on the High Speed Expansion Connector. These clocks may have a secondary function of being CSI0_MCLK and CSI1_MCLK. If these clocks can’t be supported by the SoC than an alternative GPIO or No-Connect is allowed by the specifications.
+- The Helio X20 Development Board implements two CSI clocks which are connected directly to the MT6797 SoC. These signals are driven at 1.8V.
 
 ### USB
 
 < Example >
 
-- The 96Boards specification calls for a USB Data line interface to be present on the High Speed Expansion Connector. 
-- The Helio X20 Development Board implements this requirement by routing USB channel 3 from the USB HUB to the High Speed Expansion Connector. 
+- The 96Boards specification calls for a USB Data line interface to be present on the High Speed Expansion Connector.
+- The Helio X20 Development Board implements this requirement by routing USB channel 3 from the USB HUB to the High Speed Expansion Connector.
 
-### HSIC 
+### HSIC
 
 < Example >
 
-- The 96Boards specification calls for an optional MIPI-HSIC interface to be present on the High Speed Expansion Connector. 
-- The Helio X20 Development Board implementation doesn’t support this optional requirement. 
+- The 96Boards specification calls for an optional MIPI-HSIC interface to be present on the High Speed Expansion Connector.
+- The Helio X20 Development Board implementation doesn’t support this optional requirement.
 
-### Reserved 
+### Reserved
 
 < Example >
 
@@ -696,8 +700,8 @@ The pin 60 of the High Speed Expansion Connector is pulled up to VIO18_PMU via 1
 
 < Additional details and schematics related to power conditioning circuitry to allow hobbyists from power from other sources >
 
-- An 8V to 18V power from a dedicated DC jack J901. 
-- An 8V to 18V power from the SYS_DCIN pins on the Low Speed Expansion Connector CON7001. 
+- An 8V to 18V power from a dedicated DC jack J901.
+- An 8V to 18V power from the SYS_DCIN pins on the Low Speed Expansion Connector CON7001.
 
 > Note: Please refer to the mechanical size of the DC plug below.The inside diameter of the plug is 1.7mm，the outer diameter of the plug is 4.75mm.The positive electrode of the DC plug is in the inside, and the negative pole is outside.
 

--- a/ConsumerEdition/imx7-96/installation/README.md
+++ b/ConsumerEdition/imx7-96/installation/README.md
@@ -1,3 +1,7 @@
+---
+title: Installation with the i.MX7 96
+permalink: /documentation/ConsumerEdition/imx7-96/installation/
+---
 # Installation
 
 For more installation information and instructions, please visit one of following guides:

--- a/ConsumerEdition/imx7-96/installation/board-recovery.md
+++ b/ConsumerEdition/imx7-96/installation/board-recovery.md
@@ -1,4 +1,8 @@
+---
+title: Board Recovery for i.MX7 96
+permalink: /documentation/ConsumerEdition/imx7-96/installation/board-recovery.md.html
+---
 # Helio X20 Board Recovery
 
-- For most users, a board could be “recovered” from a software failure by reloading the operating system using the instructions provided above. 
+- For most users, a board could be “recovered” from a software failure by reloading the operating system using the instructions provided above.
 - You could also recover the board by Backup & reset option in Settings Application.

--- a/ConsumerEdition/imx7-96/support/README.md
+++ b/ConsumerEdition/imx7-96/support/README.md
@@ -1,9 +1,13 @@
+---
+title: Support for i.MX7 96
+permalink: /documentation/ConsumerEdition/imx7-96/support/
+---
 # Support
 
 Please take advantage of the many i.MX7 96 resources available to you through 96Boards, Arrow, and more...
 
 - [96Boards i.MX7 96 Forum](https://discuss.96boards.org/c/products/imx7-96)
-   - The DragonBoard has its very own 96Boards forum. If you can't find a pre-existing thread that addresses your issue, start your own and let the community help out! 
+   - The DragonBoard has its very own 96Boards forum. If you can't find a pre-existing thread that addresses your issue, start your own and let the community help out!
 - [Coursera](https://www.coursera.org/specializations/internet-of-things)
    - i.MX7 96 uses the same specification! Students from the [University of California San Diego](https://ucsd.edu/) put together an "Internet of Things" (IoT) course focused around the DragonBoard 410c (again, same specification as i.MX7 96!). It is free to audit, or you can purchase the specialization package for a cool certificate!
 - [Report a bug!](../../../Report_a_bug.md)


### PR DESCRIPTION
Fixes for a couple of 404's being raised by the custom link checker currently in place on the Bamboo CI builds for 96boards.org

@shovanuk 