### PR TITLE
documentation: Added many folders and README to organize mezzanine se…

### DIFF
--- a/mezzanine/aerocore2/files/README.md
+++ b/mezzanine/aerocore2/files/README.md
@@ -1,0 +1,8 @@
+---
+title: Files for AeroCore 2
+permalink: /documentation/mezzanine/aerocore2/files/
+redirect_from: /documentation/mezzanine/aerocore2/README.md/
+---
+## AeroCore 2 Files
+
+Coming soon...

--- a/mezzanine/aerocore2/guides/README.md
+++ b/mezzanine/aerocore2/guides/README.md
@@ -1,0 +1,5 @@
+---
+title: AeroCore 2 Guides
+permalink: /documentation/mezzanine/aerocore2/guides/
+---
+# AeroCore 2 Guides

--- a/mezzanine/aerocore2/images/README.md
+++ b/mezzanine/aerocore2/images/README.md
@@ -1,0 +1,8 @@
+---
+title: Images for AeroCore 2
+permalink: /documentation/mezzanine/aerocore2/images/
+redirect_from: /documentation/mezzanine/aerocore2/README.md/
+---
+## AeroCore 2 Images
+
+Coming soon...

--- a/mezzanine/audio-mezzanine/files/README.md
+++ b/mezzanine/audio-mezzanine/files/README.md
@@ -1,0 +1,8 @@
+---
+title: Files for Audio Mezzanine
+permalink: /documentation/mezzanine/audio-mezzanine/files/
+redirect_from: /documentation/mezzanine/audio-mezzanine/README.md/
+---
+## Audio Mezzanine Files
+
+Coming soon...

--- a/mezzanine/audio-mezzanine/guides/README.md
+++ b/mezzanine/audio-mezzanine/guides/README.md
@@ -1,0 +1,5 @@
+---
+title: Audio Mezzanine Guides
+permalink: /documentation/mezzanine/audio-mezzanine/guides/
+---
+# Audio Mezzanine Guides

--- a/mezzanine/audio-mezzanine/images/README.md
+++ b/mezzanine/audio-mezzanine/images/README.md
@@ -1,0 +1,8 @@
+---
+title: Images for Audio Mezzanine
+permalink: /documentation/mezzanine/audio-mezzanine/images/
+redirect_from: /documentation/mezzanine/audio-mezzanine/README.md/
+---
+## Audio Mezzanine Images
+
+Coming soon...

--- a/mezzanine/d3camera/files/README.md
+++ b/mezzanine/d3camera/files/README.md
@@ -1,0 +1,8 @@
+---
+title: Files for D3 Camera Mezzanine
+permalink: /documentation/mezzanine/d3camera/files/
+redirect_from: /documentation/mezzanine/d3camera/README.md/
+---
+## D3 Camera Mezzanine Files
+
+Coming soon...

--- a/mezzanine/d3camera/guides/README.md
+++ b/mezzanine/d3camera/guides/README.md
@@ -1,0 +1,5 @@
+---
+title: D3 Camera Mezzanine Guides
+permalink: /documentation/mezzanine/d3camera/guides/
+---
+# D3 Camera Mezzanine Guides

--- a/mezzanine/d3camera/images/README.md
+++ b/mezzanine/d3camera/images/README.md
@@ -1,0 +1,8 @@
+---
+title: Images for D3 Camera Mezzanine
+permalink: /documentation/mezzanine/d3camera/images/
+redirect_from: /documentation/mezzanine/d3camera/README.md/
+---
+## D3 Camera Mezzanine Images
+
+Coming soon...

--- a/mezzanine/ethernetcard/files/README.md
+++ b/mezzanine/ethernetcard/files/README.md
@@ -1,0 +1,8 @@
+---
+title: Files for PoE Mezzanine
+permalink: /documentation/mezzanine/ethernetcard/files/
+redirect_from: /documentation/mezzanine/ethernetcard/README.md/
+---
+## PoE Mezzanine Files
+
+Coming soon...

--- a/mezzanine/ethernetcard/guides/README.md
+++ b/mezzanine/ethernetcard/guides/README.md
@@ -1,0 +1,5 @@
+---
+title: PoE Mezzanine Guides
+permalink: /documentation/mezzanine/ethernetcard/guides/
+---
+# PoE Mezzanine Guides

--- a/mezzanine/ethernetcard/images/README.md
+++ b/mezzanine/ethernetcard/images/README.md
@@ -1,0 +1,8 @@
+---
+title: Images for PoE Mezzanine
+permalink: /documentation/mezzanine/ethernetcard/images/
+redirect_from: /documentation/mezzanine/ethernetcard/README.md/
+---
+## PoE Mezzanine Images
+
+Coming soon...

--- a/mezzanine/linkspritesensorkit/files/README.md
+++ b/mezzanine/linkspritesensorkit/files/README.md
@@ -1,0 +1,8 @@
+---
+title: Files for LinkSprite Mezzanine Kit
+permalink: /documentation/mezzanine/linkspritesensorkit/files/
+redirect_from: /documentation/mezzanine/linkspritesensorkit/README.md/
+---
+## LinkSprite Mezzanine Kit Files
+
+Coming soon...

--- a/mezzanine/linkspritesensorkit/guides/README.md
+++ b/mezzanine/linkspritesensorkit/guides/README.md
@@ -1,0 +1,5 @@
+---
+title: LinkSprite Mezzanine Kit Guides
+permalink: /documentation/mezzanine/linkspritesensorkit/guides/
+---
+# LinkSprite Mezzanine Kit Guides

--- a/mezzanine/linkspritesensorkit/images/README.md
+++ b/mezzanine/linkspritesensorkit/images/README.md
@@ -1,0 +1,8 @@
+---
+title: Images for LinkSprite Mezzanine Kit
+permalink: /documentation/mezzanine/linkspritesensorkit/images/
+redirect_from: /documentation/mezzanine/linkspritesensorkit/README.md/
+---
+## LinkSprite Mezzanine Kit Images
+
+Coming soon...

--- a/mezzanine/mipiadapter/files/README.md
+++ b/mezzanine/mipiadapter/files/README.md
@@ -1,0 +1,8 @@
+---
+title: Files for MIPI Adapter
+permalink: /documentation/mezzanine/mipiadapter/files/
+redirect_from: /documentation/mezzanine/mipiadapter/README.md/
+---
+## MIPI Adapter Files
+
+Coming soon...

--- a/mezzanine/mipiadapter/guides/README.md
+++ b/mezzanine/mipiadapter/guides/README.md
@@ -1,0 +1,5 @@
+---
+title: MIPI Adapter Guides
+permalink: /documentation/mezzanine/mipiadapter/guides/
+---
+# MIPI Adapter Guides

--- a/mezzanine/mipiadapter/images/README.md
+++ b/mezzanine/mipiadapter/images/README.md
@@ -1,0 +1,8 @@
+---
+title: Images for MIPI Adapter
+permalink: /documentation/mezzanine/mipiadapter/images/
+redirect_from: /documentation/mezzanine/mipiadapter/README.md/
+---
+## MIPI Adapter Images
+
+Coming soon...

--- a/mezzanine/neonkey/files/README.md
+++ b/mezzanine/neonkey/files/README.md
@@ -1,0 +1,8 @@
+---
+title: Files for NeonKey
+permalink: /documentation/mezzanine/neonkey/files/
+redirect_from: /documentation/mezzanine/neonkey/README.md/
+---
+## NeonKey Files
+
+Coming soon...

--- a/mezzanine/neonkey/images/README.md
+++ b/mezzanine/neonkey/images/README.md
@@ -1,0 +1,8 @@
+---
+title: Images for NeonKey
+permalink: /documentation/mezzanine/neonkey/images/
+redirect_from: /documentation/mezzanine/neonkey/README.md/
+---
+## NeonKey Images
+
+Coming soon...

--- a/mezzanine/sensors-mezzanine/files/README.md
+++ b/mezzanine/sensors-mezzanine/files/README.md
@@ -1,0 +1,8 @@
+---
+title: Files for Sensors Mezzanine
+permalink: /documentation/mezzanine/sensors-mezzanine/files/
+redirect_from: /documentation/mezzanine/sensors-mezzanine/README.md/
+---
+## Sensors Mezzanine Files
+
+Coming soon...

--- a/mezzanine/sensors-mezzanine/guides/README.md
+++ b/mezzanine/sensors-mezzanine/guides/README.md
@@ -1,0 +1,5 @@
+---
+title: Sensors Mezzanine Guides
+permalink: /documentation/mezzanine/sensors-mezzanine/guides/
+---
+# Sensors Mezzanine Guides

--- a/mezzanine/sensors-mezzanine/images/README.md
+++ b/mezzanine/sensors-mezzanine/images/README.md
@@ -1,0 +1,8 @@
+---
+title: Images for Sensors Mezzanine
+permalink: /documentation/mezzanine/sensors-mezzanine/images/
+redirect_from: /documentation/mezzanine/sensors-mezzanine/README.md/
+---
+## Sensors Mezzanine Images
+
+Coming soon...

--- a/mezzanine/stm32/files/README.md
+++ b/mezzanine/stm32/files/README.md
@@ -1,0 +1,8 @@
+---
+title: Files for STM32
+permalink: /documentation/mezzanine/stm32/files/
+redirect_from: /documentation/mezzanine/stm32/README.md/
+---
+## STM32 Files
+
+Coming soon...

--- a/mezzanine/stm32/guides/README.md
+++ b/mezzanine/stm32/guides/README.md
@@ -1,0 +1,5 @@
+---
+title: STM32 Guides
+permalink: /documentation/mezzanine/stm32/guides/
+---
+# STM32 Guides

--- a/mezzanine/stm32/images/README.md
+++ b/mezzanine/stm32/images/README.md
@@ -1,0 +1,8 @@
+---
+title: Images for STM32
+permalink: /documentation/mezzanine/stm32/images/
+redirect_from: /documentation/mezzanine/stm32/README.md/
+---
+## STM32 Images
+
+Coming soon...

--- a/mezzanine/uartserial/files/README.md
+++ b/mezzanine/uartserial/files/README.md
@@ -1,0 +1,8 @@
+---
+title: Files for UART Serial Mezzanine
+permalink: /documentation/mezzanine/uartserial/files/
+redirect_from: /documentation/mezzanine/uartserial/README.md/
+---
+## UART Serial Mezzanine Files
+
+Coming soon...

--- a/mezzanine/uartserial/guides/README.md
+++ b/mezzanine/uartserial/guides/README.md
@@ -1,0 +1,5 @@
+---
+title: UART Serial Mezzanine Guides
+permalink: /documentation/mezzanine/uartserial/guides/
+---
+# UART Serial Mezzanine Guides

--- a/mezzanine/uartserial/images/README.md
+++ b/mezzanine/uartserial/images/README.md
@@ -1,0 +1,8 @@
+---
+title: Images for UART Serial Mezzanine
+permalink: /documentation/mezzanine/uartserial/images/
+redirect_from: /documentation/mezzanine/uartserial/README.md/
+---
+## UART Serial Mezzanine Images
+
+Coming soon...


### PR DESCRIPTION
Documentation:

Setting the hiarchy in the mezzanine folder within the documentation
repository. This is required to build out the various guides,files and images
to be used around documentation repository and website repo.

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>