### PR TITLE
Dragonboard410c: Guides: Modify EnableSPI guide

### DIFF
--- a/ConsumerEdition/DragonBoard-410c/Guides/EnableSPI.md
+++ b/ConsumerEdition/DragonBoard-410c/Guides/EnableSPI.md
@@ -3,104 +3,136 @@ title: Enabling SPI on Dragonboard 410c with SPIDEV
 permalink: /documentation/ConsumerEdition/DragonBoard-410c/Guides/EnableSPI.md.html
 redirect_from: /db410c-getting-started/Guides/EnableSPI.md/
 ---
+
 # Enabling SPI on Dragonboard 410c with SPIDEV
 
-This tutorial will show how to build and flash a DragonBoard 410c boot image with SPI enabled using SPIDEV.
+This document provides instructions for enabling SPI (Serial Peripheral Interface)
+subsystem on Dragonboard410c along with SPIDEV userspace interface.
 
-> Note: LT Debian 16.06 release MUST be used as base (**Step 1**). The 16.06 LT release already includes the SPIDEV kernel module, you will only need to change the device tree file (and boot image).
+# Table of Contents
 
-***
+- [1) SPIDEV](#1-spidev)
+- [2) Modifying device tree](#2-modifying-device-tree)
+- [3) Building device tree](#3-building-device-tree)
+- [4) Flashing boot and rootfs image](#4-flashing-boot-and-rootfs-image)
+- [5) Testing SPIDEV](#5-testing-spidev)
 
-### Step 1: **Flash the 16.06 LT Debian release:**
+ ***
 
-First make sure you are running the 16.06 LT Debian release. The following folder contains all the necessary files:
+# 1) SPIDEV
 
-- https://builds.96boards.org/releases/dragonboard410c/linaro/debian/16.06/
+SPI devices have a limited userspace API, supporting basic half-duplex
+read() and write() access to SPI slave devices. SPIDEV is a kernel driver
+used to provide userspace interface to SPI subsystem.
 
-From the above link, download your desired `rootfs` and `boot` image
-- linaro-jessie-{alip or developer}-qcom-snapdragon-arm64-*.img.gz
-- boot-linaro-jessie-qcom-snapdragon-arm64-*.img.gz
+This driver can be enabled by the following Kconfig option:
 
-Fastboot installation instructions (using a Linux host machine) can be found [here](../Installation/LinuxFastboot.md)
+CONFIG_SPI_SPIDEV=y (or)
+CONFIG_SPI_SPIDEV=m
 
-A pre-built, flashable boot image is available (skip steps 2-5). Simply replace the boot image downloaded from builds.96boards with the boot-db410c-spi.img [downloaded here](http://people.linaro.org/~ricardo.salveti/boot-db410c-spi.img) and proceed to fastboot installation instruction above. Once you have finished flashing both pre-built `rootfs` and `boot` images, skip to **Step 6** for SPI test commands.
+First option builds the driver into kernel while the later builds it as
+a separate module. Since latest linaro builds have this option enabled
+by default, only device tree modification is required.
 
-### Step 2: Customize the device tree to export the spidev devices (low and high speed expansion headers):
+# 2) Modifying device tree
+
+For using SPIDEV driver it is necessary to add the relevant device tree node.
+Following instructions are used to add SPIDEV nodes into Dragonboard410c
+device tree.
+
+1. Clone the kernel
 
 ```shell
 $ git clone -n http://git.linaro.org/landing-teams/working/qualcomm/kernel.git
 $ cd kernel
-$ git checkout -b kernel-16.06 debian-qcom-dragonboard410c-16.06
+$ git checkout -b kernel-<RELEASE> debian-qcom-dragonboard410c-<RELEASE>
 ```
+> Note: Replace < RELEASE > with latest release version found
+[here](http://builds.96boards.org/releases/dragonboard410c/linaro/debian/latest/)
 
-Change the device tree file to include the spidev devices:
+2. Add SPIDEV nodes to device tree
+
+Apply the following diff to `arch/arm64/boot/dts/qcom/apq8016-sbc.dtsi`
 
 ```
-$ git diff
-diff --git a/arch/arm64/boot/dts/qcom/apq8016-sbc.dtsi
-b/arch/arm64/boot/dts/qcom/apq8016-sbc.dtsi
-index aeed816..f6714a5 100644
+diff --git a/arch/arm64/boot/dts/qcom/apq8016-sbc.dtsi b/arch/arm64/boot/dts/qcom/apq8016-sbc.dtsi
+index 5d0d5a3..c4a5ba7 100644
 --- a/arch/arm64/boot/dts/qcom/apq8016-sbc.dtsi
 +++ b/arch/arm64/boot/dts/qcom/apq8016-sbc.dtsi
-@@ -477,3 +477,23 @@
- &vidc {
-        status = "okay";
+@@ -476,6 +476,26 @@
+        };
  };
-+
-+/* On Low speed expansion */
+ 
++/* On Low speed expansion header */
 +&blsp_spi5 {
-+       status = "okay";
-+       spidev@0 {
-+               compatible = "spidev";
-+               spi-max-frequency = <50000000>;
-+               reg = <0>;
-+       };
++               status = "okay";
++               spidev@0 {
++                               compatible = "spidev";
++                               spi-max-frequency = <500000>;
++                               reg = <0>;
++               };
 +};
 +
-+/* On High speed expansion */
++/* On High speed expansion header */
 +&blsp_spi3 {
-+       status = "okay";
-+       spidev@0 {
-+               compatible = "spidev";
-+               spi-max-frequency = <50000000>;
-+               reg = <0>;
-+       };
++               status = "okay";
++               spidev@0 {
++                               compatible = "spidev";
++                               spi-max-frequency = <500000>;
++                               reg = <0>;
++               };
 +};
++
 ```
 
-### Step 3: Build the device tree file to be used (dtb):
+# 3) Building device tree
+
+Build the device tree with above mentioned changes.
 
 ```shell
 $ export ARCH=arm64
 $ export CROSS_COMPILE=<path to your GCC cross compiler>/aarch64-linux-gnu-
 $ make defconfig distro.config
-$ make dtbs
+$ make -j$(nproc) dtbs
 ```
-
-### Step 4: Build the new boot image, using the new device tree files:
+Now, prepare the boot image.
 
 ```shell
 $ git clone git://codeaurora.org/quic/kernel/skales
 $ ./skales/dtbTool -o dt.img -s 2048 arch/arm64/boot/dts/qcom/
-$ wget http://builds.96boards.org/releases/dragonboard410c/linaro/debian/16.06/initrd.img-4.4.9-linaro-lt-qcom
-$ wget https://builds.96boards.org/releases/dragonboard410c/linaro/debian/16.06/Image
-$ ./skales/mkbootimg --kernel Image --ramdisk
-initrd.img-4.4.9-linaro-lt-qcom --output boot-db410c.img --dt dt.img
---pagesize 2048 --base 0x80000000 --cmdline
-"root=/dev/disk/by-partlabel/rootfs rw rootwait
-console=ttyMSM0,115200n8"
+$ wget http://builds.96boards.org/releases/dragonboard410c/linaro/debian/latest/initrd.img-<KERNELRELEASE>-linaro-lt-qcom
+$ wget http://builds.96boards.org/releases/dragonboard410c/linaro/debian/latest/Image
+$ ./skales/mkbootimg --kernel Image \
+                   --ramdisk initrd.img.<KERNELRELEASE>-linaro-lt-qcom \
+                   --output boot-db410c.img \
+                   --dt dt.img \
+                   --pagesize 2048 \
+                   --base 0x80000000 \
+                   --cmdline "root=/dev/disk/by-partlabel/rootfs rw rootwait console=ttyMSM0,115200n8"
 ```
 
-### Step 5: Flash the new boot image and boot the device.
+> Note: Replace < KERNELRELEASE > with latest kernel release version found
+[here](http://builds.96boards.org/releases/dragonboard410c/linaro/debian/latest/).
 
-> Note: DragonBoard 410c must first be booted into fastboot mode
+# 4) Flashing boot and roofs image
 
-`$ sudo fastboot flash boot boot-db410c.img`
+Boot Dragonboard410c into fastboot mode by following the
+[instructions](https://www.96boards.org/documentation/ConsumerEdition/DragonBoard-410c/Installation/LinuxFastboot.md.html).
 
-Kernel warning when booting the kernel:
+1. Download latest `rootfs` image from
+[here](http://builds.96boards.org/releases/dragonboard410c/linaro/debian/latest/linaro-*-alip-qcom-snapdragon-arm64-*.img.gz).
+2. Flash boot and rootfs images onto Dragonboard410c
+
+```shell
+$ sudo fastboot flash boot boot-db410c.img
+$ sudo fastboot flash rootfs linaro-<DEBIANRELEASE>-alip-qcom-snapdragon-arm64-<BUILD>.img
+```
+> Note: Replace < DEBIANRELEASE > and < BUILD > according to the downloaded rootfs image.
+
+### Kernel warning when booting the kernel:
 
 Since the SPIDEV module is not a representation of a real hardware,
-the kernel will produce a warning when booting the system, such as:
+kernel will produce a warning when booting the system, such as:
 
 ```shell
 [   11.566840] spidev spi1.0: buggy DT: spidev listed directly in DT
@@ -111,20 +143,24 @@ the kernel will produce a warning when booting the system, such as:
 The device will still be functional, so just ignore while testing the
 SPIDEV devices.
 
-#### Step 6: Test with spi-test
+# 5) Testing SPIDEV
 
-```
-$ wget https://raw.githubusercontent.com/KnCMiner/spi-test/master/spi-test.c
-$ gcc -o spi-test spi-test.c
-$ ./spi-test -CHO -D /dev/spidev0.0  0xaa,0xbb,0xcc,0,0,0,0,0
+Login to Dragnoboard410c and execute the following commands to test
+SPI using SPIDEV module with the help of `spidev_test` utility.
+
+```shell
+$ wget https://raw.githubusercontent.com/torvalds/linux/master/tools/spi/spidev_test.c
+$ gcc -o spidev_test spidev_test.c
+$ sudo ./spidev_test -CHO -D /dev/spidev0.0  0xaa,0xbb,0xcc,0,0,0,0,0
  AA BB CC 00 00 00 00 00
  00 00 00 00 00 00 00 00
 ```
 
-Loopback test:
+Since, SPI driver in Dragonboard410c supports Loopback functionality, we can
+test that too without any hardware connections.
 
 ```shell
-$ ./spi-test -CHO -D /dev/spidev0.0  0xaa,0xbb,0xcc,0,0,0,0,0 --loop
+$ sudo ./spidev_test -CHO -D /dev/spidev0.0  0xaa,0xbb,0xcc,0,0,0,0,0 --loop
  AA BB CC 00 00 00 00 00
  AA BB CC 00 00 00 00 00
 ```

--- a/ConsumerEdition/guides/mraa/gpio/README.md
+++ b/ConsumerEdition/guides/mraa/gpio/README.md
@@ -4,10 +4,30 @@ permalink: /documentation/ConsumerEdition/guides/mraa/gpio/README.md.html
 ---
 # Examples on how to use GPIO using mraa library
 
-Following examples are provided to use GPIO using MRAA library.
+Following examples are provided in this repository to use GPIO using MRAA library.
 
-1. mraa_goio.c
+1. mraa_gpio.c
 2. mraa_gpio.cpp
 3. mraa_gpio.py
 
-Each examples consists of the compilation instruction and usage description.
+**Usage:**
+
+> Prerequisite: Debian running on 96Boards CE with libmraa installed
+
+* Copy the examples to 96Boards CE
+* Build the C/C++ examples:
+```shell
+$ gcc mraa_gpio.c -o gpio_c
+$ g++ mraa_gpio.cpp -o gpio_c++
+```
+* Execute the examples:
+```shell
+$ sudo ./gpio_c
+$ sudo ./gpio_c++
+$ sudo python mraa_gpio.py
+```
+
+**Expected Behaviour:**
+
+Toggles GPIO23 and GPIO24 on Low Speed expansion header.
+ 

--- a/ConsumerEdition/guides/mraa/i2c/README.md
+++ b/ConsumerEdition/guides/mraa/i2c/README.md
@@ -7,7 +7,7 @@ permalink: /documentation/ConsumerEdition/guides/mraa/i2c/README.md.html
 
 Following examples are provided to use I2C using MRAA library.
 
-1. mraa_goio.c
+1. mraa_i2c.c
 2. mraa_i2c.cpp
 3. mraa_i2c.py
 

--- a/ConsumerEdition/guides/mraa/i2c/README.md
+++ b/ConsumerEdition/guides/mraa/i2c/README.md
@@ -11,4 +11,23 @@ Following examples are provided to use I2C using MRAA library.
 2. mraa_i2c.cpp
 3. mraa_i2c.py
 
-Each examples consists of the compilation instruction and usage description.
+**Usage:**
+
+> Prerequisite: Debian running on 96Boards CE with libmraa installed
+
+* Copy the examples to 96Boards CE
+* Build the C/C++ examples:
+```shell
+$ gcc mraa_i2c.c -o i2c_c
+$ g++ mraa_i2c.cpp -o i2c_c++
+```
+* Execute the examples:
+```shell
+$ sudo ./i2c_c
+$ sudo ./i2c_c++
+$ sudo python mraa_i2c.py
+```
+
+**Expected Behaviour:**
+
+Checks for MPU6050 sensor at I2C bus 0. 

--- a/ConsumerEdition/guides/mraa/led/README.md
+++ b/ConsumerEdition/guides/mraa/led/README.md
@@ -10,4 +10,25 @@ Following examples are provided to use LED using MRAA library.
 2. mraa_led.cpp
 3. mraa_led.py
 
-Each examples consists of the compilation instruction and usage description.
+**Usage:**
+
+> Prerequisite: Debian running on 96Boards CE with libmraa installed
+
+* Copy the examples to 96Boards CE
+* Build the C/C++ examples:
+```shell
+$ gcc mraa_led.c -o led_c
+$ g++ mraa_led.cpp -o led_c++
+```
+* Execute the examples:
+```shell
+$ sudo ./led_c
+$ sudo ./led_c++
+$ sudo python mraa_led.py
+```
+
+**Expected Behaviour:**
+
+1. Reads maximum brightness value for USER1 led and turns it
+ON/OFF depending on current state. 
+2. Finally sets led trigger to heartbeat.

--- a/ConsumerEdition/guides/mraa/uart/README.md
+++ b/ConsumerEdition/guides/mraa/uart/README.md
@@ -10,4 +10,23 @@ Following examples are provided to use UART using MRAA library.
 2. mraa_uart.cpp
 3. mraa_uart.py
 
-Each examples consists of the compilation instruction and usage description.
+**Usage:**
+
+> Prerequisite: Debian running on 96Boards CE with libmraa installed
+
+* Copy the examples to 96Boards CE
+* Build the C/C++ examples:
+```shell
+$ gcc mraa_uart.c -o uart_c
+$ g++ mraa_uart.cpp -o uart_c++
+```
+* Execute the examples:
+```shell
+$ sudo ./uart_c
+$ sudo ./uart_c++
+$ sudo python mraa_uart.py
+```
+
+**Expected Behaviour:**
+
+Sends "Hello Mraa" string to `/dev/tty96B0` uart port.


### PR DESCRIPTION
Restructure the EnableSPI guide with latest build info

Changes:
1. Specified latest build
2. Removed instruction for using custom boot image with device tree changes as it seems to be not needed.
2. Used spidev_test utility in kernel
3. Reduced SPIDEV max frequency to 500KHz as reported by the utility.

Fixes #187

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>