### PR TITLE
ce/guides/mraa: Fixed permalinks

### DIFF
--- a/ConsumerEdition/guides/mraa/gpio/README.md
+++ b/ConsumerEdition/guides/mraa/gpio/README.md
@@ -1,6 +1,6 @@
 ---
 title: Examples on how to use GPIO using mraa library
-permalink: /documentation/ConsumerEdition/guides/mraa/gpio/README.md.html
+permalink: /documentation/ConsumerEdition/guides/mraa/gpio/
 ---
 # Examples on how to use GPIO using mraa library
 

--- a/ConsumerEdition/guides/mraa/i2c/README.md
+++ b/ConsumerEdition/guides/mraa/i2c/README.md
@@ -1,6 +1,6 @@
 ---
 title: Examples on how to use I2C using mraa library
-permalink: /documentation/ConsumerEdition/guides/mraa/i2c/README.md.html
+permalink: /documentation/ConsumerEdition/guides/mraa/i2c/
 ---
 # Examples on how to use I2C using mraa library
 

--- a/ConsumerEdition/guides/mraa/led/README.md
+++ b/ConsumerEdition/guides/mraa/led/README.md
@@ -1,6 +1,6 @@
 ---
 title: Examples on how to use on board LED using mraa library
-permalink: /documentation/ConsumerEdition/guides/mraa/led/README.md.html
+permalink: /documentation/ConsumerEdition/guides/mraa/led/
 ---
 # Examples on how to use on board LED using mraa library
 

--- a/ConsumerEdition/guides/mraa/uart/README.md
+++ b/ConsumerEdition/guides/mraa/uart/README.md
@@ -1,6 +1,6 @@
 ---
 title: Examples on how to use UART using mraa library
-permalink: /documentation/ConsumerEdition/guides/mraa/uart/README.md.html
+permalink: /documentation/ConsumerEdition/guides/mraa/uart/
 ---
 # Examples on how to use UART using mraa library
 


### PR DESCRIPTION
Removed README.md.html extensions from all README
markdowns.

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>