### PR TITLE
Poplar: use 'master' branch instead of 'latest' for poplar-tools

### DIFF
--- a/EnterpriseEdition/Poplar/BuildSource/README.md
+++ b/EnterpriseEdition/Poplar/BuildSource/README.md
@@ -9,5 +9,5 @@ Instructions for building and flashing the components of your favorite operating
 
 ## Contents
 
-- [Linaro Debian (Developer)](https://github.com/Linaro/poplar-tools/blob/latest/build_instructions.md)
+- [Linaro Debian (Developer)](https://github.com/Linaro/poplar-tools/blob/master/build_instructions.md)
    - This link will take you to seperate Linaro repository with build, and flashing instructions.

--- a/EnterpriseEdition/Poplar/GettingStarted/README.md
+++ b/EnterpriseEdition/Poplar/GettingStarted/README.md
@@ -53,7 +53,7 @@ Coming soon...
 
 ## Starting the board for the first time
 
-Before starting your Poplar for the first time, it is suggested to build and flash the appropriate software. Instructions on how to do this can be found [HERE](https://github.com/Linaro/poplar-tools/blob/latest/build_instructions.md)
+Before starting your Poplar for the first time, it is suggested to build and flash the appropriate software. Instructions on how to do this can be found [HERE](https://github.com/Linaro/poplar-tools/blob/master/build_instructions.md)
 
 ***
 
@@ -61,7 +61,7 @@ Before starting your Poplar for the first time, it is suggested to build and fla
 
 If you are already familiar with the Poplar board and would like to change out the stock operating system, please proceed to one of the following pages:
 
-- [Board Recovery](https://github.com/Linaro/poplar-tools/blob/latest/build_instructions.md)
+- [Board Recovery](https://github.com/Linaro/poplar-tools/blob/master/build_instructions.md)
    - If at any time your board is having unexplainable issues, it is suggested to attempt a board recovery. These instructions will guide you through a succesfull board recovery.
 - [Support](../Support/)
    - From bug reports and current issues, to forum access and other useful resources, we want to help you find answers

--- a/EnterpriseEdition/Poplar/Support/README.md
+++ b/EnterpriseEdition/Poplar/Support/README.md
@@ -13,5 +13,5 @@ Please take advantage of the many Board-X resources available to you through 96B
 - [Report a bug!](../../../Extras/Report_a_bug.md)
    - Instructions on how to report bugs for any of our 96Boards hardware and software, this includes the Board-X!
 - [Poplar Tools](https://github.com/Linaro/poplar-tools)
-- [Board Recovery](https://github.com/Linaro/poplar-tools/blob/latest/build_instructions.md)
+- [Board Recovery](https://github.com/Linaro/poplar-tools/blob/master/build_instructions.md)
    - Bricked board? Many software issues can be fixed with a simple "board recovery"


### PR DESCRIPTION
We plan to kill 'latest' branch and use 'master' instead, as
poplar-tools is the 'upstream' repository, and 'master' should be the
most idiomatic one to use.

Signed-off-by: Shawn Guo <shawn.guo@linaro.org>