### PR TITLE
Broken links in Documentation

### DIFF
--- a/ConsumerEdition/dragonboard820c/README.md
+++ b/ConsumerEdition/dragonboard820c/README.md
@@ -1,3 +1,8 @@
+---
+title: Using the DragonBoard™ 820c
+permalink: /documentation/ConsumerEdition/dragonboard820c/
+---
+
 # Using the DragonBoard™ 820c
 
 A comprehensive guide to using the [DragonBoard 820c](https://www.96boards.org/products/dragonboard820c/) Consumer Edition development board. This guide is written by the [96Boards](https://www.96boards.org) team at [Linaro](http://www.linaro.org) with community contributions and links to third-party content.

--- a/ConsumerEdition/guides/mraa/README.md
+++ b/ConsumerEdition/guides/mraa/README.md
@@ -12,11 +12,11 @@ peripherals in 96Boards CE platforms.
 
 - [Installation guide](install.md)
    - Learn how to install mraa library on 96Boards CE
-- [Using GPIO](gpio/README.md.html)
+- [Using GPIO](gpio/)
    - Examples on how to use GPIO using mraa library
-- [Using I2C](i2c/README.md.html)
+- [Using I2C](i2c/)
    - Examples on how to use I2C using mraa library
-- [Using LED](led/README.md.html)
+- [Using LED](led/)
    - Examples on how to use on board LED using mraa library
-- [Using UART](uart/README.md.html)
+- [Using UART](uart/)
    - Examples on how to use UART using mraa library

--- a/EnterpriseEdition/Poplar/GettingStarted/README.md
+++ b/EnterpriseEdition/Poplar/GettingStarted/README.md
@@ -61,7 +61,7 @@ Before starting your Poplar for the first time, it is suggested to build and fla
 
 If you are already familiar with the Poplar board and would like to change out the stock operating system, please proceed to one of the following pages:
 
-- [Board Recovery](https://github.com/96boards-poplar/Documentation/blob/master/recovery.md)
+- [Board Recovery](https://github.com/96boards-poplar/Documentation/blob/master/debian_build_instructions.md)
    - If at any time your board is having unexplainable issues, it is suggested to attempt a board recovery. These instructions will guide you through a succesfull board recovery.
 - [Support](../Support/)
    - From bug reports and current issues, to forum access and other useful resources, we want to help you find answers

--- a/EnterpriseEdition/Poplar/Guides/README.md
+++ b/EnterpriseEdition/Poplar/Guides/README.md
@@ -10,6 +10,6 @@ These guides will help to get you started with a variety of available on-boards 
 
 | Guide                                                                                                         | Descripion                                                                                                                 |
 |:-------------------------------------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------------------------------------------|
-| [Debian System Recovery](https://github.com/96boards-poplar/Documentation/blob/master/recovery.md)  | Describes the process for creating a USB flash drive suitable for use in recovering a Poplar system from a "bricked" state |
+| [Debian System Recovery](https://github.com/96boards-poplar/Documentation/blob/master/debian_build_instructions.md)  | Describes the process for creating a USB flash drive suitable for use in recovering a Poplar system from a "bricked" state |
 | [Debian Bootable USB](https://github.com/daniel-thompson/poplar-usbstick)                                     | An automatic build script to generate a bootable debian-on-a-stick image for poplar.                                       |
 | [Gigabit NAS](gigabit-nas.md)                                                                                 | Instructions for creating a smb(Samba) based NAS leveraging the USB3.0 and Gigabit Ethernet capabilities                   |

--- a/EnterpriseEdition/Poplar/Support/README.md
+++ b/EnterpriseEdition/Poplar/Support/README.md
@@ -13,5 +13,5 @@ Please take advantage of the many Board-X resources available to you through 96B
 - [Report a bug!](../../../Extras/Report_a_bug.md)
    - Instructions on how to report bugs for any of our 96Boards hardware and software, this includes the Board-X!
 - [Poplar Tools](https://github.com/96boards-poplar/poplar-tools)
-- [Board Recovery](https://github.com/96boards-poplar/Documentation/blob/master/recovery.md)
+- [Board Recovery](https://github.com/96boards-poplar/Documentation/blob/master/debian_build_instructions.md)
    - Bricked board? Many software issues can be fixed with a simple "board recovery"


### PR DESCRIPTION
Fixes for broken links:

* Updated broken links on mraa guides page.
*  Updated broken links to recovery.md Poplar file


@shovanuk @sdrobertw 