### PR TITLE
Added front matter to pages causing broken links ~ removed anchor from broken links.

### DIFF
--- a/ConsumerEdition/B2260/Downloads/Debian.md
+++ b/ConsumerEdition/B2260/Downloads/Debian.md
@@ -10,10 +10,10 @@ permalink: /documentation/ConsumerEdition/B2260/Downloads/Debian.md.html
 
 ## SD Card image
 
-|   SD Card Image   | Build Directory ([Latest](http://builds.96boards.org/snapshots/b2260/linaro/debian/latest/)) |
+|   SD Card Image   | Build Directory ([Latest]()http://builds.96boards.org/snapshots/b2260/linaro/debian/latest/) |
 |:------------------|:------------------------------------|
-|  Debian (Alip)  |[Download](http://builds.96boards.org/snapshots/b2260/linaro/debian/latest/b2260-stretch_alip_*.img.gz) |
-|  Debian (Developer)  |[Download](http://builds.96boards.org/snapshots/b2260/linaro/debian/latest/b2260-stretch_developer_*.img.gz) |
+|  Debian (Alip)  |[Download]()http://builds.96boards.org/snapshots/b2260/linaro/debian/latest/b2260-stretch_alip_*.img.gz |
+|  Debian (Developer)  |[Download]()http://builds.96boards.org/snapshots/b2260/linaro/debian/latest/b2260-stretch_developer_*.img.gz |
 
 ### Continue to [Installation page](../Installation/)
 

--- a/ConsumerEdition/dragonboard820c/README.md
+++ b/ConsumerEdition/dragonboard820c/README.md
@@ -9,22 +9,22 @@ A comprehensive guide to using the [DragonBoard 820c](https://www.96boards.org/p
 
 ## Software
 
-- [Downloads](downloads/README.md)
+- [Downloads](downloads/)
    - Already familiar with your 96Boards? Skip the board bring up sections and go straight to your download!
-- [Installation](installation/README.md)
+- [Installation](installation/)
    - Choose and install an operating system on your DragonBoard 820c
-- [Build from Source](build/README.md)
+- [Build from Source](build/)
    - Instructions for building and flashing the components of your favorite operating systems
 
 ## Documenation
 
-- [Getting Started](getting-started/README.md)
+- [Getting Started](getting-started/)
    - Learn about your DragonBoard 820c board, how to prepare and set up for basic use
-- [Useful Guides](guides/README.md)
+- [Useful Guides](guides/)
    - These guides will help to get you started with a variety of available on-boards software
-- [Vendor Documentation](vendor-docs/README.md)
+- [Vendor Documentation](vendor-docs/)
    - Discover our list of sponsored DragonBoard 820c documents, these include User Guides and Application notes
-- [Hardware Documentation](HardwareDocs/README.md)
+- [Hardware Documentation](hardware-docs/)
    - Explore what makes your DragonBoard 820c unique, technical specifications, schematics, hardware notes and more...
-- [Support](Support/README.md)
+- [Support](support/)
    - From bug reports and current issues, to forum access and other useful resources, we want to help you find answers

--- a/ConsumerEdition/dragonboard820c/downloads/README.md
+++ b/ConsumerEdition/dragonboard820c/downloads/README.md
@@ -1,3 +1,7 @@
+---
+title: DragonBoard820c Downloads
+permalink: /documentation/ConsumerEdition/dragonboard820c/downloads/
+---
 ## Downloads
 
 The DragonBoard 820c comes pre-installed with Android (if purchased in a kit, OS can differ). If you would like to switch the Operating System to Linux based on Debian or go back to Android after using Linux, update the existing software images on your board, or unbrick your board, this page provides links to the latest software downloads.

--- a/ConsumerEdition/dragonboard820c/getting-started/README.md
+++ b/ConsumerEdition/dragonboard820c/getting-started/README.md
@@ -1,3 +1,7 @@
+---
+title: Getting Started with the DragonBoard™ 820c
+permalink: /documentation/ConsumerEdition/dragonboard820c/getting-started/
+---
 # Getting Started
 
 Learn about your DragonBoard™ 820c board as well as how to prepare and set up for basic use
@@ -78,13 +82,13 @@ The following subsections should describe how to get started with the DragonBoar
 
 If you are already familiar with the DragonBoard 820c and would like to change out the stock operating system, please proceed to one of the following pages:
 
-- [Downloads page](../Downloads/README.md): This page lists all Linaro and 3rd party operating systems available for the DragonBoard 820c
-- [Installation page](../Installation/README.md): If you already have the images you need, this page has information on how to install the different operating systems onto your DragonBoard 820c
-- [Board Recovery](../Installation/BoardRecovery.md)
+- [Downloads page](../downloads/): This page lists all Linaro and 3rd party operating systems available for the DragonBoard 820c
+- [Installation page](../installation/): If you already have the images you need, this page has information on how to install the different operating systems onto your DragonBoard 820c
+- [Board Recovery](../installation/board-recovery.md)
    - If at any time your board is having unexplainable issues, it is suggested to attempt a board recovery. These instructions will guide you through a succesfull board recovery.
-- [Troubleshooting](../Troubleshooting/README.md)
+- [Troubleshooting](../support/)
    - From bug reports and current issues, to forum access and other useful resources, we want to help you find answers
 
-Back to the [DragonBoard 820c documentation home page](../README.md)
+Back to the [DragonBoard 820c documentation home page](../)
 
 ***

--- a/ConsumerEdition/dragonboard820c/guides/README.md
+++ b/ConsumerEdition/dragonboard820c/guides/README.md
@@ -1,3 +1,7 @@
+---
+title: Useful DragonBoard™ 820c Guides
+permalink: /documentation/ConsumerEdition/dragonboard820c/guides/
+---
 # Useful Guides
 
 These guides will help to get you started with a variety of available on-boards software

--- a/ConsumerEdition/dragonboard820c/hardware-docs/README.md
+++ b/ConsumerEdition/dragonboard820c/hardware-docs/README.md
@@ -1,3 +1,7 @@
+---
+title: DragonBoard™ 820c Hardware Documentation
+permalink: /documentation/ConsumerEdition/dragonboard820c/hardware-docs/
+---
 # Hardware Documentation
 
 Explore what makes your DragonBoard 820c unique, technical specifications, schematics, hardware notes and more... This page allows you to see what is under the "DragonBoard 820c hood" by offering static documentation published directly from the board vendors.

--- a/ConsumerEdition/dragonboard820c/installation/README.md
+++ b/ConsumerEdition/dragonboard820c/installation/README.md
@@ -1,3 +1,7 @@
+---
+title: DragonBoard820c Installation
+permalink: /documentation/ConsumerEdition/dragonboard820c/installation/
+---
 # Installation
 
 Stand alone DragonBoard 820c will ship with the Android image. If the DragonBoard 820c is purchased as part of a kit, it may have a different pre-loaded operating system.
@@ -34,13 +38,13 @@ This method requires the following hardware:
 - USB Mouse and/or keyboard
 - HDMI Monitor with full size HDMI cable
 
-Go to the [Downloads page](../Downloads/README.md) to get your SD card image.
+Go to the [Downloads page](../downloads/) to get your SD card image.
 
 Choose host machine
 
-- [Linux](LinuxSD.md)
-- [Mac](MacSD.md)
-- [Windows](WindowsSD.md)
+- [Linux](linux-sd.md)
+- [Mac](mac-sd.md)
+- [Windows](windows-sd.md)
 
 ***
 
@@ -56,11 +60,11 @@ This method requires the following hardware:
 - USB Mouse and/or keyboard (not required to perform flash)
 - HDMI Monitor with full size HDMI cable (not required to perform flash)
 
-Go to the [Downloads page](../Downloads/README.md) to get your bootloader, boot image, and root file system image (rootfs).
+Go to the [Downloads page](../downloads/) to get your bootloader, boot image, and root file system image (rootfs).
 
 Choose host machine
 
-- [Linux](LinuxFastboot.md)
+- [Linux](linux-fastboot.md)
 
 ***
 

--- a/ConsumerEdition/dragonboard820c/installation/board-recovery.md
+++ b/ConsumerEdition/dragonboard820c/installation/board-recovery.md
@@ -1,3 +1,7 @@
+---
+title: DragonBoard™ 820c Board Recovery
+permalink: /documentation/ConsumerEdition/dragonboard820c/installation/board-recovery.md.html
+---
 # DragonBoard 410c Board Recovery
 
 This page outlines steps needed to recover your DragonBoard 410c board from a bricked software state. This instruction set is suggested to those who are experiences boot issues due to a corrution in the file system and/or other software components.
@@ -6,13 +10,13 @@ There are a couple ways to recover your DragonBoard 410c from a "bricked" state.
 
 ## SD card Recovery image
 
-In most cases this will be your sure-fire way to recover your board from a software bricked state. A recovery image has been created and made ready to be flashed onto a micro SD card. Simply download the SD card recovery image, and follow the sd card installation instructions found on our [Installation page](README.md).
+In most cases this will be your sure-fire way to recover your board from a software bricked state. A recovery image has been created and made ready to be flashed onto a micro SD card. Simply download the SD card recovery image, and follow the sd card installation instructions found on our [Installation page](installation/).
 
 - Download [SD Card Recovery image](http://builds.96boards.org/releases/dragonboard410c/linaro/rescue/latest/dragonboard410c_sdcard_rescue-*.zip)
-- Choose host machine under SD card installation instructions from [Installation Page](README.md)
+- Choose host machine under SD card installation instructions from [Installation Page](installation/)
 
 > Note: For those already familiar with the SD card flashing process, 96Boards build folder can be found [here](http://builds.96boards.org/releases/dragonboard410c/linaro/rescue/latest/) 
 
 ## Fastboot recovery
 
-In many cases, simply re-flashing the bootloader, boot image, and root file system, using the [fastboot method](README.md#fastboot-method) is enough. While the generic fastboot method might not always work due to certain complications, the sd card recovery image is always available (as seen above).
+In many cases, simply re-flashing the bootloader, boot image, and root file system, using the [fastboot method](installation/#fastboot-method) is enough. While the generic fastboot method might not always work due to certain complications, the sd card recovery image is always available (as seen above).

--- a/ConsumerEdition/dragonboard820c/installation/linux-fastboot.md
+++ b/ConsumerEdition/dragonboard820c/installation/linux-fastboot.md
@@ -1,3 +1,7 @@
+---
+title: DragonBoard™ 820c Linux Fastboot
+permalink: /documentation/ConsumerEdition/dragonboard820c/installation/linux-fastboot.md.html
+---
 ##Linux Host
 
 This section show how to install a new operating system to your DragonBoard™ 410c using the fastboot method on a Linux host computer.

--- a/ConsumerEdition/dragonboard820c/installation/linux-sd.md
+++ b/ConsumerEdition/dragonboard820c/installation/linux-sd.md
@@ -1,3 +1,7 @@
+---
+title: DragonBoard™ 820c Linux Host Installation
+permalink: /documentation/ConsumerEdition/dragonboard820c/installation/linux-sd.md.html
+---
 ## Linux Host
 
 This section show how to install an operating system to your DragonBoard™ 410c using the SD Card method on a Linux host computer.

--- a/ConsumerEdition/dragonboard820c/installation/mac-sd.md
+++ b/ConsumerEdition/dragonboard820c/installation/mac-sd.md
@@ -1,3 +1,7 @@
+---
+title: DragonBoard™ 820c Mac OS X Host Installation
+permalink: /documentation/ConsumerEdition/dragonboard820c/installation/mac-sd.md.html
+---
 ## Mac OS X Host
 
 This section show how to install an operating system to your DragonBoard™ 410c using the SD Card method on a Mac OS X host computer.

--- a/ConsumerEdition/dragonboard820c/installation/windows-sd.md
+++ b/ConsumerEdition/dragonboard820c/installation/windows-sd.md
@@ -1,3 +1,7 @@
+---
+title: DragonBoard™ 820c Windows Host Installation
+permalink: /documentation/ConsumerEdition/dragonboard820c/installation/windows-sd.md.html
+---
 ## Windows Host
 
 This section show how to install an operating system to your DragonBoard™ 410c using the SD Card method on a Windows host computer.

--- a/ConsumerEdition/dragonboard820c/support/README.md
+++ b/ConsumerEdition/dragonboard820c/support/README.md
@@ -1,3 +1,7 @@
+---
+title: DragonBoard™ 820c Troubleshooting
+permalink: /documentation/ConsumerEdition/dragonboard820c/hardware-docs/
+---
 # Troubleshooting
 
 Please take advantage of the many DragonBoard 820c resources available to you through Qualcomm, 96Boards, Arrow, and Coursera.
@@ -12,5 +16,5 @@ Please take advantage of the many DragonBoard 820c resources available to you th
    - DragonBoard 820c uses a very similar specification! Students from the University of California San Diego put together an "Internet of Things" (IoT) course focused around the DragonBoard 410c. It is free to audit, or you can purchase the specialization package for a cool certificate!
 - [Report a bug!](../../../Report_a_bug.md)
    - Instructions on how to report bugs for any of our 96Boards hardware and software, this includes the DragonBoard 820c!
-- [Board Recovery](../Installation/BoardRecovery.md)
+- [Board Recovery](../installation/board-recovery.md)
    - Bricked board? Many software issues can be fixed with a simple "board recovery"

--- a/ConsumerEdition/dragonboard820c/vendor-docs/README.md
+++ b/ConsumerEdition/dragonboard820c/vendor-docs/README.md
@@ -1,0 +1,5 @@
+---
+title: DragonBoard™ 820c Vendor Docs
+permalink: /documentation/ConsumerEdition/dragonboard820c/vendor-docs/
+---
+# DragonBoard™ 820c Vendor Docs

--- a/mezzanine/audio-mezzanine/Guides/beginner-guides/README.md
+++ b/mezzanine/audio-mezzanine/Guides/beginner-guides/README.md
@@ -1,6 +1,6 @@
 ---
 title: Audio Mezzanine Beginner Guides 
-permalink: /documentation/mezzanine/audio-mezzanine/Guides/advanced-guides/
+permalink: /documentation/mezzanine/audio-mezzanine/Guides/beginner-guides/
 ---
 # Beginner Guides
 


### PR DESCRIPTION

96boards is failing to build due to some pages being referenced through the breadcrumb that don't have front matter. This should let 96boards builds go through providing no other broken links surface after merging this PR.

@shovanuk 