### PR TITLE
Fix casing for the links

### DIFF
--- a/consumer/dragonboard410c/downloads/README.md
+++ b/consumer/dragonboard410c/downloads/README.md
@@ -15,8 +15,8 @@ The DragonBoard 410c comes pre-installed with Android (if purchased in a kit, OS
 
 ### Linaro supported operating systems
 
-- [Debian](Debian.md)
-- [OpenEmbedded](OpenEmbedded.md)
+- [Debian](debian.md)
+- [OpenEmbedded](open-embedded.md)
 
 ***
 
@@ -24,7 +24,7 @@ The DragonBoard 410c comes pre-installed with Android (if purchased in a kit, OS
 
 Other operating systems supported on DragonBoard 410c, offered by partners.
 
-- [Android](Android.md)
+- [Android](android.md)
 - [Ubuntu Core](https://developer.ubuntu.com/core/get-started/dragonboard-410c)
 - [Windows IoT Core](https://developer.microsoft.com/en-us/windows/iot/docs/getstarted/dragonboard/stable/getstartedstep1)
 - [Fedora](https://nullr0ute.com/2017/11/getting-started-with-fedora-on-the-96boards-dragonboard/)


### PR DESCRIPTION
When browsing via github these links are not followed correctly.

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>