### PR TITLE
Fixed DragonBoard820c Getting Started broken images / redirect loop fix

### DIFF
--- a/consumer/dragonboard820c/getting-started/README.md
+++ b/consumer/dragonboard820c/getting-started/README.md
@@ -34,8 +34,8 @@ Learn about your DragonBoard™ 820c board as well as how to prepare and set up 
 
 The following subsections should describe how to get started with the DragonBoard 820c using the release build shipped with the boards. The DragonBoard 820c is ready to use “out of the box” with a preinstalled version of Android (unless otherwise specified).
 
-<img src="https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/additional-doc/images/images-board/sd/dragonboard820c-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/additional-doc/images/images-board/sd/dragonboard820c-front-sd.png?raw=true" width="480" height="250" />
-<img src="https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/additional-doc/images/images-board/sd/dragonboard820c-back-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/additional-doc/images/images-board/sd/dragonboard820c-back-sd.png?raw=true" width="480" height="250" />
+<img class="lazyload" src="https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/additional-docs/images/images-board/sd/dragonboard820c-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/additional-docs/images/images-board/sd/dragonboard820c-front-sd.png?raw=true" width="480" height="250" />
+<img class="lazyload" src="https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/additional-docs/images/images-board/sd/dragonboard820c-back-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/additional-docs/images/images-board/sd/dragonboard820c-back-sd.png?raw=true" width="480" height="250" />
 
 ## Features
 

--- a/iot/carbon/hardware-docs/README.md
+++ b/iot/carbon/hardware-docs/README.md
@@ -4,7 +4,6 @@ permalink: /documentation/iot/carbon/hardware-docs/
 redirect_from:
 - /documentation/IoTEdition/carbon/hardware-docs/README.md/
 - /documentation/IoTEdition/carbon/hardware-docs/README.md
-- /documentation/iot/carbon/hardware-docs/
 ---
 # Hardware Documentation
 


### PR DESCRIPTION
Fixed DragonBoard820c Getting Started broken images and removed redirect that would cause a problematic loop.

@sdrobertw @shovanuk 