### PR TITLE
Update links to builds

### DIFF
--- a/consumer/guides/zram_swapspace.md
+++ b/consumer/guides/zram_swapspace.md
@@ -14,7 +14,7 @@ It is not as fast as actual RAM, but it is close enough for the speed degradatio
 
 ## Software
 
-- Linaro Debian Operating system snapshot Builds (http://builds.96boards.org/snapshots/)
+- Linaro Debian Operating system snapshot Builds (http://snapshots.linaro.org/96boards/)
 - If you are not using the DragonBoard410c, you will need to rebuild the kernel using ```CONFIG_ZRAM=m``` and ```CONFIG_ZSMALLOC=m``` Kconfig option.
 
 ## Steps


### PR DESCRIPTION
The builds were moved from 96boards.org to linaro.org