### PR TITLE
db820c: unlikely to ship with Android by default

### DIFF
--- a/consumer/dragonboard820c/downloads/README.md
+++ b/consumer/dragonboard820c/downloads/README.md
@@ -4,7 +4,7 @@ permalink: /documentation/consumer/dragonboard820c/downloads/
 ---
 ## Downloads
 
-The DragonBoard 820c comes pre-installed with Android (if purchased in a kit, OS can differ). If you would like to switch the Operating System to Linux based on Debian or go back to Android after using Linux, update the existing software images on your board, or unbrick your board, this page provides links to the latest software downloads.
+If you would like to change the Operating System for you board, update the existing software images on your board, or unbrick your board, this page provides links to the latest software downloads.
 
 ***
 


### PR DESCRIPTION
The text here is just a copy 'n paste from DB410C and risks misleading people (for examples see: http://discuss.96boards.org/t/820c-android-support/4094/2 ).

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>