### PR TITLE
db410c: Update the rescue links

### DIFF
--- a/consumer/dragonboard410c/build/open-embedded.md
+++ b/consumer/dragonboard410c/build/open-embedded.md
@@ -13,7 +13,7 @@ the OE/Yocto images, please refer the generic [OpenEmbedded guide](../../guides/
 
 Build artifacts from your OE build will be flashed into the on-board eMMC (in contrast to some other boards which run their images from an SDcard). The OpenEmbedded BSP layer assumes that the _Linux_ Bootloaders and eMMC partition layout are used on the
 board (not the _Android_ ones; by default DragonBoards come pre-configured with the Android eMMC partition layout).
-You can download the latest Linux bootloader package for Dragonboard410c from [here](http://builds.96boards.org/releases/dragonboard410c/linaro/rescue/latest/)
+You can download the latest Linux bootloader package for Dragonboard410c from [here](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/)
 to your development host, it will be named something like `dragonboard410c_bootloader_emmc_linux-<version>.zip`.
 
 Whether your board is using the Android eMMC partition layout or the Linux partition eMMC layout, you will use the

--- a/consumer/dragonboard410c/downloads/android.md
+++ b/consumer/dragonboard410c/downloads/android.md
@@ -26,8 +26,8 @@ redirect_from:
 
 | Bootloader                                                                                                                              |
 |:----------------------------------------------------------------------------------------------------------------------------------------|
-| [Download](https://builds.96boards.org/releases/dragonboard410c/linaro/rescue/latest/dragonboard410c_bootloader_emmc_android-*.zip)     |
-| [Release Notes](http://builds.96boards.org/releases/dragonboard410c/linaro/rescue/latest/)                                              |
+| [Download](https://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragonboard410c_bootloader_emmc_android-*.zip)     |
+| [Release Notes](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/)                                              |
 
 | Stable Snapshot 99                                                                                                                        |
 | :---------------------------------------------------------------------------------------------------------------------------------------- |

--- a/consumer/dragonboard410c/downloads/debian.md
+++ b/consumer/dragonboard410c/downloads/debian.md
@@ -31,8 +31,8 @@ redirect_from:
 
 | Bootloader                                                                                                                             |
 |:---------------------------------------------------------------------------------------------------------------------------------------|
-| [Download](http://builds.96boards.org/releases/dragonboard410c/linaro/rescue/latest/dragonboard410c_bootloader_emmc_linux-*.zip)       |
-| [Release Notes](http://builds.96boards.org/releases/dragonboard410c/linaro/rescue/latest/)                                             |
+| [Download](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragonboard410c_bootloader_emmc_linux-*.zip)       |
+| [Release Notes](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/)                                             |
 
 | Boot image                                                                                                                             |
 |:---------------------------------------------------------------------------------------------------------------------------------------|

--- a/consumer/dragonboard410c/downloads/open-embedded.md
+++ b/consumer/dragonboard410c/downloads/open-embedded.md
@@ -15,8 +15,8 @@ redirect_from:
 
 | Bootloader                                                                                                                              |
 |:----------------------------------------------------------------------------------------------------------------------------------------|
-| [Download](http://builds.96boards.org/releases/dragonboard410c/linaro/rescue/latest/dragonboard410c_bootloader_emmc_linux-*.zip)        |
-| [Release Notes](http://builds.96boards.org/releases/dragonboard410c/linaro/rescue/latest/)      |
+| [Download](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragonboard410c_bootloader_emmc_linux-*.zip)        |
+| [Release Notes](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/)      |
 
 Choose between RPB and RPB-Wayland. You will need to download the "boot image" and your choice of "Desktop" or "Console" rootfs.
 

--- a/consumer/dragonboard410c/installation/board-recovery.md
+++ b/consumer/dragonboard410c/installation/board-recovery.md
@@ -15,10 +15,10 @@ There are a couple ways to recover your DragonBoard 410c from a "bricked" state.
 
 In most cases this will be your sure-fire way to recover your board from a software bricked state. A recovery image has been created and made ready to be flashed onto a micro SD card. Simply download the SD card recovery image, and follow the sd card installation instructions found on our [Installation page](README.md).
 
-- Download [SD Card Recovery image](http://builds.96boards.org/releases/dragonboard410c/linaro/rescue/latest/dragonboard410c_sdcard_rescue-*.zip)
+- Download [SD Card Recovery image](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragonboard410c_sdcard_rescue-*.zip)
 - Choose host machine under SD card installation instructions from [Installation Page](README.md)
 
-> Note: For those already familiar with the SD card flashing process, 96Boards build folder can be found [here](http://builds.96boards.org/releases/dragonboard410c/linaro/rescue/latest/)
+> Note: For those already familiar with the SD card flashing process, 96Boards build folder can be found [here](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/)
 
 ## Fastboot recovery
 


### PR DESCRIPTION
The rescue images have just migrated to releases.linaro.org. Let's track them.

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>