### PR TITLE
consumer/imx7-96: Added README to additional-docs and fixed broken links

### DIFF
--- a/consumer/imx7-96/README.md
+++ b/consumer/imx7-96/README.md
@@ -1,7 +1,6 @@
 ---
 title: Documentation for i.MX7 96 - Meerkat
 permalink: /documentation/consumer/imx7-96/
-redirect_from:  /documentation/ConsumerEdition/imx7-96/
 ---
 # Using the i.MX7 96 - Meerkat<sup>®</sup>
 

--- a/consumer/imx7-96/additional-docs/README.md
+++ b/consumer/imx7-96/additional-docs/README.md
@@ -1,0 +1,19 @@
+---
+title: Additional Docs for i.MX7-96
+permalink: /documentation/consumer/dragonboard410c/additional-docs/
+---
+# Board Images
+
+Each 96Boards development board must provide six images, 3 x High Definition and 3 x Standard Definition. These images should be sized and named accordingly. These images should be uploaded to this folder and made available to community for viewing and/or download.
+
+#### 1500x974 - 300dpi
+- BoardName_Front_HD
+- BoardName_Back_HD
+- BoardName_Angle_HD
+
+#### 770x500 - 72dpi
+- BoardName_Front_SD
+- BoardName_Back_SD
+- BoardName_Angle_SD
+
+***

--- a/consumer/imx7-96/downloads/README.md
+++ b/consumer/imx7-96/downloads/README.md
@@ -1,7 +1,6 @@
 ---
 title: Downloads for i.MX7 96
 permalink: /documentation/consumer/imx7-96/downloads/
-redirect_from: /documentation/ConsumerEdition/imx7-96/downloads/
 ---
 ## Downloads
 

--- a/consumer/imx7-96/getting-started/README.md
+++ b/consumer/imx7-96/getting-started/README.md
@@ -1,7 +1,6 @@
 ---
 title: Getting Started with i.MX7 96Boards - Meerkat
 permalink: /documentation/consumer/imx7-96/getting-started/
-redirect_from:  /documentation/ConsumerEdition/imx7-96/getting-started/
 ---
 # Getting Started
 

--- a/consumer/imx7-96/guides/README.md
+++ b/consumer/imx7-96/guides/README.md
@@ -1,7 +1,6 @@
 ---
 title: Useful Guides for i.MX7 96
 permalink: /documentation/consumer/imx7-96/guides/
-redirect_from: /documentation/ConsumerEdition/imx7-96/guides/
 ---
 
 # Useful Guides

--- a/consumer/imx7-96/guides/software-guide.md
+++ b/consumer/imx7-96/guides/software-guide.md
@@ -1,8 +1,6 @@
 ---
 title: Software Guide
 permalink: /documentation/consumer/imx7-96/guides/software-guide.md.html
-redirect_from:
-- /documentation/ConsumerEdition/imx7-96/Guides/software-guide.md.html
 ---
 # Software Guide
 

--- a/consumer/imx7-96/guides/software-guide.md
+++ b/consumer/imx7-96/guides/software-guide.md
@@ -44,7 +44,7 @@ cd ~/Projects/meerkat96
 # Building source and images
 
 
-Please refer to the [i.MX7 96Board User Guide](guides/user-guide.md) for instructions on retrieving and configuring the VM for use.
+Please refer to the [i.MX7 96Board User Guide](user-guide.md) for instructions on retrieving and configuring the VM for use.
 
 For convenience of development full source and pre-compiled images for console and GUI configurations are provided. The virtual machine is pre-configured with the necessary tools and packages for compilation.
 

--- a/consumer/imx7-96/guides/software-guide.md
+++ b/consumer/imx7-96/guides/software-guide.md
@@ -107,7 +107,7 @@ The script can also place individual portions of the compiled images. Run **mk_m
 
 Pre-compiled images for both the console and graphical systems are available from https://novtech.sharefile.com in the **03 – Compiled SD Images** directory.
 
-Images in **03.01 – Card Images** can be programmed directly to SD/MMC cards with **dd** or Win32DiskImager per instructions in the [i.MX7 96Boards Meerkat<sup>®</sup> User Guide](../guides/user-guide.md)
+Images in **03.01 – Card Images** can be programmed directly to SD/MMC cards with **dd** or Win32DiskImager per instructions in the [i.MX7 96Boards Meerkat<sup>®</sup> User Guide](user-guide.md)
 
 Images in **03.02 – Card Contents** can be downloaded to the VM extracted. These images can be written to cards using the **mk_meerkat_sd** script included in their respective directories.
 

--- a/consumer/imx7-96/guides/user-guide.md
+++ b/consumer/imx7-96/guides/user-guide.md
@@ -1,8 +1,6 @@
 ---
 title: User Guide for i.MX7 96Board - Meerkat
 permalink: /documentation/consumer/imx7-96/guides/user-guide.md.html
-redirect_from:
-- /documentation/ConsumerEdition/i.MX7-96/Guides/user-guide.md.html
 ---
 
 # i.MX7 96Board - Meerkat<sup>®</sup> User Guide

--- a/consumer/imx7-96/hardware-docs/README.md
+++ b/consumer/imx7-96/hardware-docs/README.md
@@ -1,7 +1,6 @@
 ---
 title: Hardware Documentation for i.MX7 96
 permalink: /documentation/consumer/imx7-96/hardware-docs/
-redirect_from: /documentation/ConsumerEdition/imx7-96/hardware-docs/
 ---
 # Hardware Documentation
 

--- a/consumer/imx7-96/installation/README.md
+++ b/consumer/imx7-96/installation/README.md
@@ -1,7 +1,6 @@
 ---
 title: Installation with the i.MX7 96
 permalink: /documentation/consumer/imx7-96/installation/
-redirect_from: /documentation/ConsumerEdition/imx7-96/installation/
 ---
 # Installation
 

--- a/consumer/imx7-96/support/README.md
+++ b/consumer/imx7-96/support/README.md
@@ -1,11 +1,6 @@
 ---
 title: Support for i.MX7 96 - Meerkat<sup>®</sup>
 permalink: /documentation/consumer/imx7-96/support/
-redirect_from:
-- /documentation/ConsumerEdition/imx7-96/Support/README.md/
-- /documentation/ConsumerEdition/imx7-96/Support/
-- /documentation/consumer/imx7-96/support/README.md/
-- /imx7-96-getting-started/Support/README.md/
 ---
 # Troubleshooting
 


### PR DESCRIPTION
- Added README.md with basic image template information
- Attempt to fix imx7-96 links throughout the section
   - There seemed to be inaccurate redirects in place that were causing the build errors

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>