### PR TITLE
Removed the redirect_from from the CONTRIBUTE.md document

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,7 +1,6 @@
 ---
 title: Contribution Policy
 permalink: /documentation/CONTRIBUTE.md.html
-redirect_from: /documentation/Extras/ContributionPolicy.md.html
 ---
 
 # Contributing to 96Boards Documentation


### PR DESCRIPTION
…d is deprecated and we are now adding redirect rules to the routingrules.json file in the 96boards/website/_data folder