### PR TITLE
dragonboard410c: Add html rendering for kernel building guide

### DIFF
--- a/consumer/dragonboard410c/build/README.md
+++ b/consumer/dragonboard410c/build/README.md
@@ -11,6 +11,5 @@ redirect_from:
 
 - [OpenEmbedded/Yocto](open-embedded.md)
    - Create custom distribution based on OpenEmbedded/Yocto
-
 - [Linux Kernel](kernel.md)
    - Build Linux Kernel from source

--- a/consumer/dragonboard410c/build/README.md
+++ b/consumer/dragonboard410c/build/README.md
@@ -11,3 +11,6 @@ redirect_from:
 
 - [OpenEmbedded/Yocto](open-embedded.md)
    - Create custom distribution based on OpenEmbedded/Yocto
+
+- [Linux Kernel](kernel.md)
+   - Build Linux Kernel from source

--- a/consumer/dragonboard410c/build/kernel.md
+++ b/consumer/dragonboard410c/build/kernel.md
@@ -1,3 +1,8 @@
+---
+title: Build & Update Linux kernel
+permalink: /documentation/consumer/dragonboard410c/build/kernel.md.html
+---
+
 # Build & Update Linux kernel
   
 This page provides the Dragonboard-410c specific instructions for Linux kernel building.


### PR DESCRIPTION
This guide is missing the html rendering and also the entry in
top level README.md. Hence add these for better visibility in website.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>