### PR TITLE
update KERNELVERSION string

### DIFF
--- a/consumer/dragonboard820c/build/linux-kernel.md
+++ b/consumer/dragonboard820c/build/linux-kernel.md
@@ -41,12 +41,12 @@ $ cd kernel
 $ export ARCH=arm64
 $ export CROSS_COMPILE=<path to your GCC cross compiler>/aarch64-linux-gnu-
 $ make defconfig distro.config
-$ make -j$nproc Image dtbs KERNELRELEASE=`make kernelversion`-linaro-lt-qcom
+$ make -j$nproc Image dtbs KERNELRELEASE=`make kernelversion`-qcomlt-${ARCH}
 ```
 For building the kernel modules:
 
 ```shell
-$ make -j4 modules KERNELRELEASE=`make kernelversion`-linaro-lt-qcom
+$ make -j4 modules KERNELRELEASE=`make kernelversion`-qcomlt-${ARCH}
 ```
 
 ## Booting the Kernel


### PR DESCRIPTION
when we switch to full kernel build as Debian package, we changed the version string to be qcomlt-ARCH, we need to update the instructions accordingly.