### PR TITLE
db410c: guides: dmic: Add missing mux reset command for CIC1

### DIFF
--- a/consumer/dragonboard410c/guides/enable-dmic.md
+++ b/consumer/dragonboard410c/guides/enable-dmic.md
@@ -147,4 +147,5 @@ After recording audio, mux can be reset using the following command.
 
 ```shell
 $ amixer cset iface=MIXER,name='DEC1 MUX' 'ZERO'
+$ amixer cset iface=MIXER,name='CIC1 MUX' 'ZERO'
 ```


### PR DESCRIPTION
Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>