### PR TITLE
Broken 820c snapshots image links fixed.

### DIFF
--- a/consumer/dragonboard820c/downloads/open-embedded.md
+++ b/consumer/dragonboard820c/downloads/open-embedded.md
@@ -21,20 +21,20 @@ Choose one boot image, the root file system you choose will be based on the boot
 
 | Boot image                                                                                                                                           |
 |:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| [RPB](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/morty/latest/rpb/boot--4.11-r0-dragonboard-820c-*.img)                |
-| [RPB-Wayland](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/morty/latest/rpb-wayland/boot--4.11-r0-dragonboard-820c-*.img)|
+| [RPB](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/rpb/boot--4.14-r0-dragonboard-820c-*.img)                |
+| [RPB-Wayland](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/rpb-wayland/boot--4.14-r0-dragonboard-820c-*.img)|
 | [Release Notes](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/)                                              |
 
 Only download one root file system (Console or Desktop). You should match the type of rootfs to the boot image you downloaded above.
 
 | Rootfs image (RPB)                                                                                                                                       |
 |:-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Desktop](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/morty/latest/rpb/rpb-desktop-image-dragonboard-820c-*.rootfs.ext4.gz) | 
-| [Developer](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/morty/latest/rpb/rpb-console-image-dragonboard-820c-*.rootfs.ext4.gz) |
+| [Desktop](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/rpb/rpb-desktop-image-dragonboard-820c-*.rootfs.ext4.gz) | 
+| [Developer](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/rpb/rpb-console-image-dragonboard-820c-*.rootfs.ext4.gz) |
 
 | Rootfs image (RPB-Wayland)                                                                                                                                      | 
 |:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Desktop](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/morty/latest/rpb-wayland/rpb-weston-image-dragonboard-820c-*.rootfs.ext4.gz) | 
-| [Developer](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/morty/latest/rpb-wayland/rpb-console-image-dragonboard-820c-*.rootfs.ext4.gz) |
+| [Desktop](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/rpb-wayland/rpb-weston-image-dragonboard-820c-*.rootfs.ext4.gz) | 
+| [Developer](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/rpb-wayland/rpb-console-image-dragonboard-820c-*.rootfs.ext4.gz) |
 
 ## Continue to [Installation page](../installation)

--- a/consumer/dragonboard820c/hardware-docs/README.md
+++ b/consumer/dragonboard820c/hardware-docs/README.md
@@ -8,4 +8,4 @@ Explore what makes your DragonBoard 820c unique, technical specifications, schem
 
 ## User Guides
 
-- Hardware User Manual - [View](/consumer/dragonboard820c/hardware-docs/files/db820c-hw-user-manual.pdf)(.pdf)
+- Hardware User Manual - [View](/documentation/consumer/dragonboard820c/hardware-docs/files/db820c-hw-user-manual.pdf)(.pdf)


### PR DESCRIPTION
I've found the replacements for the 820c snapshots broken links and updated.