### PR TITLE
db410c: build: Remove parantheses in command substitution

### DIFF
--- a/consumer/dragonboard410c/build/kernel.md
+++ b/consumer/dragonboard410c/build/kernel.md
@@ -64,7 +64,7 @@ The kernel image and DTB file need to be packed into an Android boot image. Such
 - ##### Build image
   ```shell
   # DTB has to be appended to the compressed kernel image:
-  $ cat arch/$(ARCH)/boot/Image.gz arch/$(ARCH)/boot/dts/qcom/apq8016-sbc.dtb > Image.gz+dtb
+  $ cat arch/$ARCH/boot/Image.gz arch/$ARCH/boot/dts/qcom/apq8016-sbc.dtb > Image.gz+dtb
 
   # abootimg requires a ramdisk, but we don't really use it, so create a dummy one:
   $ echo "not a ramdisk" > ramdisk.img


### PR DESCRIPTION
Command substitution should be $ARCH instead of $(ARCH) while using it
in command line.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>