### PR TITLE
Fixed YAML error. An error will be raised with YAML key's without val…

### DIFF
--- a/enterprise/developerbox/installation/board-recovery.md
+++ b/enterprise/developerbox/installation/board-recovery.md
@@ -1,9 +1,6 @@
 ---
 title: Developerbox Board Recovery
-permalink:
-/documentation/enterprise/developerbox/installation/board-recovery.md.html
-redirect_from:
-
+permalink: /documentation/enterprise/developerbox/installation/board-recovery.md.html
 ---
 # Table of Contents
 


### PR DESCRIPTION
- Try and keep permalinks on one line to avoid any mishaps with parsing the front matter.
- YAML keys without a value will raise a syntax error.