### PR TITLE
developerbox: build: Improve cloning of OpenSSL

### DIFF
--- a/enterprise/developerbox/build/README.md
+++ b/enterprise/developerbox/build/README.md
@@ -52,8 +52,7 @@ cd $WORKSPACE
 git clone git://git.linaro.org/leg/noupstream/arm-trusted-firmware.git -b synquacer
 git clone git://git.linaro.org/leg/noupstream/edk2-platforms.git -b developer-box
 git clone git://git.linaro.org/leg/noupstream/edk2-non-osi.git -b developer-box
-git clone git://git.linaro.org/leg/noupstream/edk2.git -b developer-box
-git clone https://github.com/openssl/openssl  -b OpenSSL_1_1_0e
+git clone git://git.linaro.org/leg/noupstream/edk2.git -b developer-box --recursive
 ~~~
 
 ## Rebuild Trusted Firmware


### PR DESCRIPTION
EDK2 recently made OpenSSL a sub-module. Updating the clone to use this feature should help avoid version skew problems in the future.

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>