### PR TITLE
consumer/db820c/download: Removed all OE downloads from DB820c

### DIFF
--- a/consumer/dragonboard820c/downloads/open-embedded.md
+++ b/consumer/dragonboard820c/downloads/open-embedded.md
@@ -19,22 +19,6 @@ permalink: /documentation/consumer/dragonboard820c/downloads/open-embedded.md.ht
 
 Choose one boot image, the root file system you choose will be based on the boot image you download here:
 
-| Boot image                                                                                                                                           |
-|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| [RPB](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/rpb/boot--4.14-r0-dragonboard-820c-*.img)                |
-| RPB-Wayland] - Currently unavailable
-| [Release Notes](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/)                                              |
-
-Only download one root file system (Console or Desktop). You should match the type of rootfs to the boot image you downloaded above.
-
-| Rootfs image (RPB)                                                                                                                                       |
-|:-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Desktop](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/rpb/rpb-desktop-image-dragonboard-820c-*.rootfs.ext4.gz) | 
-| [Developer](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/rpb/rpb-console-image-dragonboard-820c-*.rootfs.ext4.gz) |
-
-| Rootfs image (RPB-Wayland)                                                                                                                                      | 
-|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Desktop - Currently unavailable | 
-| Developer - Currently unavailable |
+Latest OpenEmbedded snapshot images can be found [HERE](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/). Once you have downloaded your pre-built images, proceed to the installation page.
 
 ## Continue to [Installation page](../installation)


### PR DESCRIPTION
Snapshots are very volatile and are always breaking. I have changed
this page to forward user to the snapshots folder. Until there is a
release, I do not recommend linking any downloads to such volatile
snapshot folders.

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>