### PR TITLE
ee: poplar-hoperun: update links for hoperun poplar board

### DIFF
--- a/enterprise/poplar-hoperun/README.md
+++ b/enterprise/poplar-hoperun/README.md
@@ -4,7 +4,7 @@ permalink: /documentation/enterprise/poplar-hoperun/
 ---
 # Using the Poplar
 
-A comprehensive guide to using the [Poplar](https://www.96boards.org/product/poplar/) Enterprise Edition development board. This guide is written by the [96Boards](https://www.96boards.org) team at [Linaro](http://www.linaro.org) with community contributions and links to third-party content.
+A comprehensive guide to using the [Poplar](https://www.96boards.org/product/poplar-hoperun/) Enterprise Edition development board. This guide is written by the [96Boards](https://www.96boards.org) team at [Linaro](http://www.linaro.org) with community contributions and links to third-party content.
 
 ## Software
 

--- a/enterprise/poplar-hoperun/hardware-docs/README.md
+++ b/enterprise/poplar-hoperun/hardware-docs/README.md
@@ -12,4 +12,4 @@ Explore what makes your Poplar unique, technical specifications, schematics, har
 
 #### Hardware
 
-- Schematics ([View](Poplar_Schematics_vB.pdf) / [Download](https://github.com/jianguocn/documentation/raw/topic/poplar-hoperun/enterprise/poplar-hoperun/hardware-docs/Poplar_Schematics_vB.pdf))
+- Schematics ([View](Poplar_Schematics_vB.pdf) / [Download](https://github.com/96boards/documentation/raw/master/enterprise/poplar-hoperun/hardware-docs/Poplar_Schematics_vB.pdf))

--- a/enterprise/poplar-hoperun/support/README.md
+++ b/enterprise/poplar-hoperun/support/README.md
@@ -8,7 +8,7 @@ Please take advantage of the many Hoperun Poplar board resources available to yo
 
 - [96Boards Poplar Forum](https://discuss.96boards.org/c/products/poplar)
    - The Poplar has its very own 96Boards forum. If you can't find a pre-existing thread that addresses your issue, start your own and let the community help out!
-- [Poplar on Hopeun site](http://www.hihope.org/)
+- [Poplar on Hopeun site](http://hihope.org/product/Poplar/)
 - [Report a bug!](../../../Extras/Report_a_bug.md)
    - Instructions on how to report bugs for any of our 96Boards hardware and software, this includes the Board-X!
 - [Poplar Tools](https://github.com/96boards-poplar/poplar-tools)


### PR DESCRIPTION
It updates following links for Hoperun Poplar board:
  - product link on 96boards website
  - poplar link on hoperun website
  - download link of schematic

Signed-off-by: Jianguo Sun <sun_jianguo@hoperun.com>