### PR TITLE
ee: fix a typo in description of video and image encoding of Poplar board

### DIFF
--- a/enterprise/poplar-hoperun/hardware-docs/hw-user-manual.md
+++ b/enterprise/poplar-hoperun/hardware-docs/hw-user-manual.md
@@ -67,7 +67,7 @@ The 96Boards Poplar board is the first TV board to be certified 96Boards Enterpr
    - Full HD JPEG hardware decoding, maximum 64 megapixels
    - PNG hardware decoding, maximum 64 megapixels
 - **Video and Image Encoding**:
-   - H.264 BP/MP/HP@level 4.2 video encoding, maximum 1x1080p@30 fps or 2x720p@30 fps decoding
+   - H.264 BP/MP/HP@level 4.2 video encoding, maximum 1x1080p@30 fps or 2x720p@30 fps encoding
    - Variable bit rate (VBR) or constant bit rate (CBR) mode
    - Low-delay encoding
    - Encoding of multiple region of interests (ROIs)

--- a/enterprise/poplar/hardware-docs/hw-user-manual.md
+++ b/enterprise/poplar/hardware-docs/hw-user-manual.md
@@ -70,7 +70,7 @@ The 96Boards Poplar board is the first TV board to be certified 96Boards Enterpr
    - Full HD JPEG hardware decoding, maximum 64 megapixels
    - PNG hardware decoding, maximum 64 megapixels
 - **Video and Image Encoding**:
-   - H.264 BP/MP/HP@level 4.2 video encoding, maximum 1x1080p@30 fps or 2x720p@30 fps decoding
+   - H.264 BP/MP/HP@level 4.2 video encoding, maximum 1x1080p@30 fps or 2x720p@30 fps encoding
    - Variable bit rate (VBR) or constant bit rate (CBR) mode
    - Low-delay encoding
    - Encoding of multiple region of interests (ROIs)


### PR DESCRIPTION
It fixes a typo in description of video and image encoding of Poplar board.

Signed-off-by: Jianguo Sun <sun_jianguo@hoperun.com>