### PR TITLE
developerbox: hardware-docs: Remove TS2GHR72V4B

### DIFF
--- a/enterprise/developerbox/hardware-docs/README.md
+++ b/enterprise/developerbox/hardware-docs/README.md
@@ -21,7 +21,6 @@ Explore what makes your Developerbox unique, technical specifications, schematic
 | Manufacturer | Part number | Description |
 | --- | --- | --- |
 | Micron RDIMM | MTA18ASF2G72PDZ-2G3 | 16GB 2RX8 PC4-2400T-RE1-11 |
-| Trancend RDIMM | TS2GHR72V4B DDR4 RDIMM | 16G 2Rx8 DDR4 2400 REG |
 | Trancend UDIMM | TS512MLH64V1H DDR4 UDIMM | 4GB 1Rx8 DDR4 2133 ECC |
 | Crucial UDIMM | CT4G4DFS824A | 4GB DDR4-2400 UDIMM 1.2V CL17 |
 


### PR DESCRIPTION
This DIMM is not working stably. Kernel compilation fails, memtester
outputs some errors. Remove it from the verified list.

Fixes: #488
Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>