### PR TITLE
db820c: add note about ModemManager interfering with qdl

### DIFF
--- a/consumer/dragonboard820c/installation/board-recovery.md
+++ b/consumer/dragonboard820c/installation/board-recovery.md
@@ -35,6 +35,20 @@ This is provided in source code, and it needs to be compiled locally. It uses li
 
 To compile qdl project, it should be as simple as running make command in the top level folder of the project.
 
+### Make sure that ModemManager is not running
+
+Some Linux distributions come with ModemManager, a tool for configuring Mobile Broadband.
+When the dragonboard is connected in USB mode, it will be identified as a Qualcomm modem,
+and ModemManager will try to configure the device. This will interfere with the QDL flashing,
+so if you have ModemManager running, you need to disable it before connecting your dragonboard.
+If you are using a Linux distribution with systemd, ModemManager can be stopped by:
+
+```shell
+$ sudo systemctl stop ModemManager
+```
+
+If you actually need ModemManager, you can start it again after the flashing is complete.
+
 ### Connecting the board in USB flashing mode (aka EDL mode)
 
 In order to force the DB820c to boot on USB (EDL mode), you need to configure S1 switch properly. S1 is on the back of the board underneath the micro SD slot. 

--- a/consumer/dragonboard820c/installation/build-linux-host.md
+++ b/consumer/dragonboard820c/installation/build-linux-host.md
@@ -59,6 +59,20 @@ $ mv dragonboard-820c-bootloader-ufs-linux-$BUILD bootloader-ufs-linux
 $ cd ~/DB820c/bootloader-ufs-linux
 ```
 
+## Make sure that ModemManager is not running
+
+Some Linux distributions come with ModemManager, a tool for configuring Mobile Broadband.
+When the dragonboard is connected in USB mode, it will be identified as a Qualcomm modem,
+and ModemManager will try to configure the device. This will interfere with the QDL flashing,
+so if you have ModemManager running, you need to disable it before connecting your dragonboard.
+If you are using a Linux distribution with systemd, ModemManager can be stopped by:
+
+```shell
+$ sudo systemctl stop ModemManager
+```
+
+If you actually need ModemManager, you can start it again after the flashing is complete.
+
 ## Flashing the bootloader
 
 At this point you are setup to Flashing the bootloader and use fastboot to load boot and rootfs images onto your DragonBoard 820c.

--- a/consumer/dragonboard820c/installation/linux-fastboot.md
+++ b/consumer/dragonboard820c/installation/linux-fastboot.md
@@ -29,6 +29,20 @@ $ cd qdl
 $ make
 ```
 
+### Make sure that ModemManager is not running
+
+Some Linux distributions come with ModemManager, a tool for configuring Mobile Broadband.
+When the dragonboard is connected in USB mode, it will be identified as a Qualcomm modem,
+and ModemManager will try to configure the device. This will interfere with the QDL flashing,
+so if you have ModemManager running, you need to disable it before connecting your dragonboard.
+If you are using a Linux distribution with systemd, ModemManager can be stopped by:
+
+```shell
+$ sudo systemctl stop ModemManager
+```
+
+If you actually need ModemManager, you can start it again after the flashing is complete.
+
 ### Connecting the DB820c
 
 * In order to force the DB820c to boot on USB, you need to configure S1 switch properly. S1 is on the back of the board underneath the micro SD slot.


### PR DESCRIPTION
If ModemManager is running, it will interfere with the flashing.
Add a note about this, and suggest how the user can disable it.

Unfortunately there are qdl instructions in three different pages,
so this note has to be added to all three pages.

Signed-off-by: Niklas Cassel <niklas.cassel@linaro.org>