### PR TITLE
developerbox: install: Simplify CentOS and RHEL install guide

### DIFF
--- a/enterprise/developerbox/installation/centos.md
+++ b/enterprise/developerbox/installation/centos.md
@@ -5,14 +5,12 @@ permalink: /documentation/enterprise/developerbox/installation/centos.html
 # Table of Contents
 
    * [Downloading install media](#downloading-install-media)
-   * [Quirks and workarounds for all deployments](#quirks-and-workarounds-for-all-deployments)
+   * [Quirks and workarounds](#quirks-and-workarounds)
+      * [[Hardware] Ensure graphics card is in the x16 slot](#hardware-ensure-graphics-card-is-in-the-x16-slot)
       * [[Hardware] USB/PCIe networking](#hardware-usbpcie-networking)
+      * [[Firmware] Ensure the system firmware version is up to date](#firmware-ensure-the-system-firmware-is-up-to-date)
       * [[Firmware] Set O/S Hardware Description to ACPI](#firmware-set-os-hardware-description-to-acpi)
       * [[Install, First boot] Disable incompatible PCIe features](#install-first-boot-disable-incompatible-pcie-features)
-   * [Quirks and workarounds for headless servers](#quirks-and-workarounds-for-headless-servers)
-      * [[Hardware] Uninstall the graphics card](#hardware-uninstall-the-graphics-card)
-   * [Quirks and workarounds for workstations](#quirks-and-workarounds-for-workstations)
-      * [[Hardware] Ensure graphics card is in the x16 slot](#hardware-ensure-graphics-card-is-in-the-x16-slot)
       * [[Install, First boot] Disable the nouveau driver](#install-first-boot-disable-the-nouveau-driver)
 
 <!-- Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc) -->
@@ -20,7 +18,8 @@ permalink: /documentation/enterprise/developerbox/installation/centos.html
 # Downloading install media
 
 The generic installer images are suitable for use on your Developerbox:
-http://mirror.centos.org/altarch/7/isos/aarch64/ . Any of the images are
+[http://mirror.centos.org/altarch/7/isos/aarch64/](http://mirror.centos.org/altarch/7/isos/aarch64/) .
+Any of the images are
 suitable but the Minimal installer it a good compromise between download
 size and functionality (~750MB and it is able to install a Minimal
 CentOS system without having to configure networking during the
@@ -33,19 +32,32 @@ guide to [Booting an operating system installer](./) which can be read
 alongside [the documentation on the CentOS
 wiki](https://wiki.centos.org/Documentation).
 
-# Quirks and workarounds for all deployments
+# Quirks and workarounds
 
 ## [Hardware] USB/PCIe networking
 
-CentOS 7 is based on the v4.11 kernel, released in April 2017.
-This kernel version does not include support for the built-in
-network interface. This must be worked around by using an external
-network device.
+CentOS 7 is based on the a kernel without support for
+the built-in network interface. This kernel version does not include
+support for the built-in
+network interface. This must be worked around by using an external network
+device.
 
 Both PCIe or USB network devices are suitable for this, although it is
 important to select a device that is already supported by the CentOS
 kernel. If in doubt, please ask on the [Developerbox
 forum](https://discuss.96boards.org/c/products/developerbox).
+
+## [Firmware] Ensure the system firmware version is up to date
+
+Full support for standards compliant PCIe enumeration was added to the
+Developerbox system firmware starting with version 38. Older versions of the
+firmware do not allow CentOS to enumerate PCIe devices.
+
+The firmware version is displayed both at the top of the firmware splash screen
+and as part of the system information displayed in the firmware menus.
+
+If your firmware is not recent enough then please see the [*System Firmware Update*
+section of the Install Guide](README.md#system-firmware-update).
 
 ## [Firmware] Set O/S Hardware Description to ACPI
 
@@ -90,36 +102,10 @@ To make the change permanent:
  * Run `sudo grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg` to
    regenerate the grub config files
 
-# Quirks and workarounds for headless servers
-
-## [Hardware] Uninstall the graphics card
-
-If you wish to use your Developerbox as a headless server it is
-recommended that the graphics card be removed entirely. When the
-graphics card is removed all console activity (both EDK2 menus and the
-Linux console) will automatically switch from using the graphics card to
-using the debug UART. The debug UART is connected to the micro-USB
-socket behind the I/O shield on the back panel.
-
-The automatic switching of the console means the system maintenance
-capabilities via the UART are equivalent to those available via
-the graphics card, and the power saved as a result of removing the
-graphics card is significant.
-
-# Quirks and workarounds for workstations
-
-## [Hardware] Ensure graphics card is in the x16 slot
-
-CentOS 7 is based on a kernel without sufficient support for
-Developerbox to access a PCIe graphics card across a bridge.
-
-Both PCIe x1 slots are connected to a bridge. If you have a graphics
-card installed in your Developerbox it must use the x16 slot.
-
 ## [Install, First boot] Disable the nouveau driver
 
 CentOS 7 configures the kernel to run with 64k pages (because they
-improve system performance), however nouveau driver for the GT-710
+improve system performance), however the nouveau driver for the GT-710
 graphics card included in the kit will not initialize successfully
 on kernels that are configured for 64k pages.
 
@@ -127,11 +113,9 @@ This can be worked around by disabling the nouveau driver. This causes
 the operating system to fallback to the EFI framebuffer configured by
 the firmware. This reduces the graphics card to a dumb device that scans
 out from a fixed frame buffer. All 3D operations will be emulated in
-software running the Cortex-A53 processors. Running a lightweight
-desktop environment with minimal or no use of 3D acceleration
-is strongly recommended. No suitable lightweight desktop is included in
-the base operating system but XFCE is available via
-[EPEL](https://fedoraproject.org/wiki/EPEL) .
+software running the Cortex-A53 processors. The default desktop environment
+will operate correctly but the lack of hardware acceleration is noticeable
+in some areas, in particular when bringing up the Activities overview.
 
 For install **and** first boot:
 
@@ -152,3 +136,21 @@ To make the change permanent:
  * Run `sudo grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg` to
    regenerate the grub config files
 
+Note that, although the default desktop is performant enough for occasional
+server maintainance, heavy desktop users may prefer to run a lightweight desktop
+environment with minimal or no use of 3D acceleration.
+No suitable lightweight desktop is included in
+the base operating system but XFCE is available via
+[EPEL](https://fedoraproject.org/wiki/EPEL) .
+
+Alternatively if you wish to use your Developerbox as a headless server it is
+possible to remove the graphics card entirely. When the
+graphics card is removed all console activity (both EDK2 menus and the
+Linux console) will automatically switch from using the graphics card to
+using the debug UART. The debug UART is connected to the micro-USB
+socket behind the I/O shield on the back panel.
+
+The automatic switching of the console means the system maintenance
+capabilities via the UART are equivalent to those available via
+the graphics card, and the power saved as a result of removing the
+graphics card is significant.

--- a/enterprise/developerbox/installation/rhel.md
+++ b/enterprise/developerbox/installation/rhel.md
@@ -6,10 +6,12 @@ permalink: /documentation/enterprise/developerbox/installation/rhel.html
 
    * [Downloading install media](#downloading-install-media)
    * [Quirks and workarounds](#quirks-and-workarounds)
+      * [[Hardware] Ensure graphics card is in the x16 slot](#hardware-ensure-graphics-card-is-in-the-x16-slot)
       * [[Hardware] USB/PCIe networking](#hardware-usbpcie-networking)
-      * [[Hardware] Uninstall the graphics card](#hardware-uninstall-the-graphics-card)
+      * [[Firmware] Ensure the system firmware version is up to date](#firmware-ensure-the-system-firmware-is-up-to-date)
       * [[Firmware] Set O/S Hardware Description to ACPI](#firmware-set-os-hardware-description-to-acpi)
       * [[Install, First boot] Disable incompatible PCIe features](#install-first-boot-disable-incompatible-pcie-features)
+      * [[Install, First boot] Disable the nouveau driver](#install-first-boot-disable-the-nouveau-driver)
 
 <!-- Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc) -->
 
@@ -19,7 +21,7 @@ Installer images for Red Hat Enterprise Linux (RHEL for ARM) can be obtained
 from Red Hat. If you qualify for the [Red Hat Developer
 Program](https://developers.redhat.com/articles/red-hat-developer-program-benefits/)
 installer images can be found at (no-cost registration required):
-https://developers.redhat.com/products/rhel/download/ .
+[https://developers.redhat.com/products/rhel/download/](https://developers.redhat.com/products/rhel/download/) .
 
 After downloading an installer image, please carefully study the list of
 platform quirks and workarounds below. If you need further information
@@ -30,50 +32,34 @@ Portal](https://access.redhat.com/).
 
 # Quirks and workarounds
 
-These quirks and workarounds assume that users of Red Hat Enterprise
-Linux value the enterprise support and/or ISV application certification
-associated with the Red Hat ecosystem, and that its users and
-administrators are reluctant to rely upon uncertified software from
-volunteer maintained sources such as Extra Packages for Enterprise Linux
-(EPEL). In such circumstances we can only recommend Developerbox for
-headless server applications.
-
-It is possible to use Developerbox as an enterprise workstation (albeit
-without hardware accelerated 3D graphics) but this [works best with an
-alternative desktop environment from a third
-party](centos.md#quirks-and-workarounds-for-workstations) and it is not
-documented here.
-
 ## [Hardware] USB/PCIe networking
 
-Red Hat Enterprise Linux 7 is based on the v4.11 kernel, released in April 2017.
-This kernel version does not include support for the built-in
-network interface. This must be worked around by using an external
-network device.
+Red Hat Enterprise Linux 7 is based on the a kernel without support for
+the built-in network interface. This kernel version does not include
+support for the built-in
+network interface. This must be worked around by using an external network
+device.
 
 Both PCIe or USB network devices are suitable for this, although it is
-important to select a device that is already supported by the Red Hat
-Enterprise Linux
+important to select a device that is already supported by the Red Hat Enterprise Linux
 kernel. If in doubt, please ask on the [Developerbox
 forum](https://discuss.96boards.org/c/products/developerbox).
 
-## [Hardware] Uninstall the graphics card
+## [Firmware] Ensure the system firmware version is up to date
 
-For server applications it is recommend that Developerbox be run as a
-headless system with the graphics card be removed entirely. When the
-graphics card is removed all console activity (both EDK2 menus and the
-Linux console) will automatically switch from using the graphics card to
-using the debug UART. The debug UART is connected to the micro-USB
-socket behind the I/O shield on the back panel.
+Full support for standards compliant PCIe enumeration was added to the
+Developerbox system firmware starting with version 38. Older versions of the
+firmware do not allow Red Hat Enterprise Linux to enumerate PCIe devices.
 
-The automatic switching of the console means the system maintenance
-capabilities via the UART are equivalent to those available via
-the graphics card, and the power saved as a result of removing the
-graphics card is significant.
+The firmware version is displayed both at the top of the firmware splash screen
+and as part of the system information displayed in the firmware menus.
+
+If your firmware is not recent enough then please see the [*System Firmware Update*
+section of the Install Guide](README.md#system-firmware-update).
 
 ## [Firmware] Set O/S Hardware Description to ACPI
 
-Red Hat Enterprise Linux 7 requires that the Developerbox platform hardware be 
+Red Hat Enterprise Linux 7 requires that the Developerbox platform hardware be
 described using ACPI. The firmware default is to use device
 tree to describe the hardware so this must be changed.
 
@@ -113,3 +99,56 @@ To make the change permanent:
  * Save the file and close the editor
  * Run `sudo grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg` to
    regenerate the grub config files
+
+## [Install, First boot] Disable the nouveau driver
+
+Red Hat Enterprise Linux configures the kernel to run with 64k pages (because they
+improve system performance), however the nouveau driver for the GT-710
+graphics card included in the kit will not initialize successfully
+on kernels that are configured for 64k pages.
+
+This can be worked around by disabling the nouveau driver. This causes
+the operating system to fallback to the EFI framebuffer configured by
+the firmware. This reduces the graphics card to a dumb device that scans
+out from a fixed frame buffer. All 3D operations will be emulated in
+software running the Cortex-A53 processors. The default desktop environment
+will operate correctly but the lack of hardware acceleration is noticeable
+in some areas, in particular when bringing up the Activities overview.
+
+For install **and** first boot:
+
+ * Wait for the grub menu to appear, then press **e** to edit the
+   commands before booting
+ * Use the editor to add `modprobe.blacklist=nouveau` to the kernel command line (this
+   is the line commencing with the word `linux`)
+ * Check this document for any other *[Install]* or *[First boot]*
+   workarounds. Once all kernel arguments are updated, boot the kernel
+   by pressing **Ctrl-X**.
+
+To make the change permanent:
+
+ * Wait for Red Hat Enterprise Linux to boot, then login and start a Terminal application
+ * Edit `/etc/default/grub` as root, for example: `sudo vi /etc/default/grub`
+ * Add `modprobe.blacklist=nouveau` to `GRUB_CMDLINE_LINUX`
+ * Save the file and close the editor
+ * Run `sudo grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg` to
+   regenerate the grub config files
+
+Note that, although the default desktop is performant enough for occasional
+server maintainance, heavy desktop users may prefer to run a lightweight desktop
+environment with minimal or no use of 3D acceleration.
+No suitable lightweight desktop is included in
+the base operating system but XFCE is available via
+[EPEL](https://fedoraproject.org/wiki/EPEL) .
+
+Alternatively if you wish to use your Developerbox as a headless server it is
+possible to remove the graphics card entirely. When the
+graphics card is removed all console activity (both EDK2 menus and the
+Linux console) will automatically switch from using the graphics card to
+using the debug UART. The debug UART is connected to the micro-USB
+socket behind the I/O shield on the back panel.
+
+The automatic switching of the console means the system maintenance
+capabilities via the UART are equivalent to those available via
+the graphics card, and the power saved as a result of removing the
+graphics card is significant.


### PR DESCRIPTION
Currently these instructions are complex and the RHEL one is full of
weasel words about graphics that, after more extensive testing, turns
out to be a bit too conservative.

Fix this by simplifying the instructions and encouraging use of
graphics.

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>