### PR TITLE
bublegum-96: Add board recovery guide

### DIFF
--- a/consumer/bubblegum-96/installation/board-recovery.md
+++ b/consumer/bubblegum-96/installation/board-recovery.md
@@ -1,0 +1,103 @@
+---
+title: BoardRecovery for Bubblegum-96
+permalink: /documentation/consumer/bubblegum-96/installation/board-recovery.md.html
+---
+# Bubblegum-96 Board Recovery
+
+This page outlines steps needed to recover your Bubblegum-96 board from a bricked software state. This instruction set is suggested to those who are experiences boot issues due to a corrution in the file system and/or other software components such as bootloader.
+
+## Installing a Bootloader
+
+For most users a board can be “recovered” from a software failure by reloading the operating system. However, if the primary bootloader in the eMMC flash memory has been corrupted then the bootloader will need to be re-installed. This section describes how to reinstall the primary bootloader.
+
+### 1) Update Host System
+
+The package list and versions on your host machine could be out of date. It is important to run a few commands prior to moving to the next step.
+
+These commands will help us make sure everything on the host machine is current:
+
+- **apt-get update:** Downloads package lists from online repositories and "updates" them to get information on the newest versions of packages and their dependencies.
+- **apt-get upgrade:** Fetches and installs newest package versions which currently exist on the system. APT must know about these new versions by way of 'apt-get update'
+- **apt-get dist-upgrade:** In addition to performing the function of upgrade, this option also intelligently handles changing dependencies with new versions of packages
+
+Note: Must be connected to the internet
+
+```shell
+$ sudo apt-get update
+$ sudo apt-get upgrade
+$ sudo apt-get dist-upgrade
+```
+
+### 2) Install Host Dependencies
+
+```shell
+$ sudo apt-get install git cmake
+$ sudo apt-get install libusb-1.0-0
+```
+
+### 3) Download, Build, and Install ADFU tool on Host
+
+This repository consists of the proprietary vendor binaries and **ADFU**
+source code. By building and installing this tool, the vendor binaries
+will be copied to the host and used during recovery process.
+
+```shell
+$ git clone https://github.com/96boards-bubblegum/linaro-adfu-tool.git
+$ cmake .
+$ make
+$ sudo make install
+```
+This will build and install the **ADFU** tool to `/usr/local/share/linaro-adfu-tool`.
+
+### 4) Download recovery image
+
+Apart from the vendor binaries downloaded from the above section, we also
+need U-Boot image for recovering the board. The following command downloads
+the pre-built U-Boot image.
+
+```shell
+$ wget https://releases.linaro.org/96boards/bubblegum/linaro/u-boot/latest/u-boot-dtb.img
+```
+
+### 5) Enter ADFU Mode
+
+The following instructions are used to recover board from bricked stage with
+the help of ROM bootloader using ADFU tool.
+
+- Make sure bubblegum-96 board is in power off mode
+- Plug in the UART debug board and connect serial console to the host PC
+   - Set baud rate as 115200
+   - Set (8N1) – [8bit data, No-parity, & 1 stop bit]
+- Connect the host PC with Bubblegum-96 USB3.0 port via type USB A-A cable
+   - USB3.0 port on Bubblegum96 board is the blue port
+   - This cable won’t provide Power, so it will not boot up the board
+- Hold down the ADFU key on the Bubblegum96 board
+- Plug in power to the Bubblegum96 board
+- Continue to hold down ADFU down the ADFU key for 2-4 seconds after the power has been plugged in
+- Release the ADFU key
+- Execute `lsusb` on host PC
+   - You will find a device ID 10d6:10d6 if Bubblegum96 board has entered adfu-mode
+
+### 6) Access 96board U-boot shell
+
+While Bubblegum96 board is in ADFU mode, execute the following commands
+in linaro-adfu-tool/ directory to access 96board u-boot shell.
+
+`$ sudo linaro-adfu-tool-bg96 u-boot-dtb.img`
+
+**Note:** if you `make install` the ADFU tool as mentioned above, you should be
+able to run linaro-adfu-tool from any path, it will search binaries from
+certain locations, such as
+
+1. /usr/local/share/linaro-adfu-tool/bg96/firmwares/
+2. /usr/share/linaro-adfu-tool/bg96/firmwares/
+3. ./firmwares/
+4. ../firmwares/
+
+While executing the above steps you can see the log in serial terminal.
+And once all the images are flashed, Bubblegum96 board will boot using U-Boot.
+Interrupt during the U-Boot booting stage to access the console and it will show
+`“owl>”` prompt.
+
+> Note: For now the binaries are only flashed on to RAM, for flashing the
+binaries on to eMMC, proceed to [Fastboot Mode](./linux-fastboot.md#enter-fastboot-mode) section.

--- a/consumer/bubblegum-96/installation/linux-fastboot.md
+++ b/consumer/bubblegum-96/installation/linux-fastboot.md
@@ -3,140 +3,56 @@ title: Linux Fastboot Installation for Bubblegum-96
 permalink: /documentation/consumer/bubblegum-96/installation/linux-fastboot.md.html
 redirect_from: /documentation/ConsumerEdition/Bubblegum-96/Installation/LinuxFastboot.md.html
 ---
-##Linux Host
+
+## Linux Host
 
 This section show how to install a new operating system to your Bubblegum-96 using the fastboot method on a Linux host computer.
 
-***
+### 1) Enter U-Boot Shell
 
-- **Step 1**: Update Host System
-- **Step 2**: Download Dependencies
-- **Step 3**: Download, Build, and Install linaro-adfu-tool
-- **Step 4**: Download required images
-- **Step 5**: Enter adfu mode
-- **Step 6**: Access 96board U-boot shell
-- **Step 7**: Enter Fastboot mode
-- **Step 8**: Flash kernel image
-- **Step 9**: Flash the root file system (rootfs)
-- **Step 10**: Create bootloader.img and flash using fastboot
-
-***
-
-
-
-
-### **Step 1:** Update Host System
-
-The package list and versions on your host machine could be out of date. It is important to run a few commands prior to moving to the next step.
-
-These commands will help us make sure everything on the host machine is current:
-
-- **apt-get update:** Downloads package lists from online repositories and "updates" them to get information on the newest versions of packages and their dependencies.
-- **apt-get upgrade:** Fetches and installs newest package versions which currently exist on the system. APT must know about these new versions by way of 'apt-get update'
-- **apt-get dist-upgrade:** In addition to performing the function of upgrade, this option also intelligently handles changing dependencies with new versions of packages
-
-Note: Must be connected to the internet
-
-```shell
-$ sudo apt-get update
-$ sudo apt-get upgrade
-$ sudo apt-get dist-upgrade
-```
-
-### **Step 2:** Download Dependencies
-
-```shell
-$ sudo apt-get install git
-$ sudo apt-get install libusb-1.0-0
-```
-
-### **Step 3:** Download, Build, and Install linaro-adfu-tool
-
-```shell
-$ git clone https://github.com/96boards-bubblegum/linaro-adfu-tool.git
-$ cmake .
-$ make
-$ make install
-```
-
-### **Step 4:** Download required images
-
-This Fastboot installation process currently works with the following operating systems:
-
-- Debian ([Download page](../downloads/debian.md))
-
-Once you have downloaded the appropriate files, continue to **Step 5**
-
-### **Step 5:** Enter adfu mode
+The following steps assumes that the board is flashed with proper bootloaders.
 
 - Make sure bubblegum-96 board is in power off mode
-- Plug in the UART debug board and connect serial console to the host PC.
-   - Set baud rate to be 115200,
-   - Set (8N1) – [8bit data, No-parity, & 1 stop bit].
-- Connect the host PC with Bubblegum-96 USB3.0 port via type USB A-A cable.
+- Plug in the UART debug board and connect serial console to the host PC
+   - Open a Serial Terminal like Minicom
+   - Set baud rate as 115200
+   - Set (8N1) – [8bit data, No-parity, & 1 stop bit]
+- Connect the host PC with Bubblegum-96 USB3.0 port via type USB A-A cable
    - USB3.0 port on Bubblegum96 board is the blue port
-   - Tthis cable won’t provide Power, so will notwont boot up the board
-- Hold down the ADFU key on the Bubblegum96 board while…
+   - This cable won’t provide Power, so it will not boot up the board
+- Plug in power to the Bubblegum96 board
 
-- Plug in power to the Bubblegum96 board.
-- Continue to hold down ADFU down the ADFU key for 2-4 seconds after the power has been plugged in
-- Release the ADFU key
-- Execute `lsusb` on host PC.
-   - You will find a device ID 10d6:10d6 if Bubblegum96  board has entered adfu-mode
-   - If Bubblegum96 board has not entered ADFU mode,  retry step 1-7
+Open serial terminal and press `Enter` while U-Boot starts to enter the
+U-Boot shell with `owl>` prompt.
 
-### **Step 6:** Access 96board U-boot shell
+> Note: If your board is not booting into U-Boot, then you may need to
+recover your board by following the [Recovery Guide](./board-recovery.md).
 
-_**[Host PC]**_
+### 2) Download required images
 
-While Bubblegum96 board is in ADFU mode, execute the following commands in /linaro-adfu-tool/ to access 96board u-boot shell.
+Download the boot and root file system images from the [Download page](../downloads/debian.md).
 
-`$ sudo linaro-adfu-tool-bg96 u-boot-dtb.img`
+Once you have downloaded the appropriate files, continue to next step.
 
-**Note:** if you `make install` the ADFU tool described in 2.1.4, you should be able to run linaro-adfu-tool from any path, [it will search firmware from certain path, such as
+### 3) Enter Fastboot mode
 
-1. /usr/local/share/linaro-adfu-tool/bg96/firmwares/
-2. /usr/share/linaro-adfu-tool/bg96/firmwares/
-3. ./firmwares/
-4. ../firmwares/
+> Note: The Fastboot mode is used to flash the images to on-board eMMC of the
+Bubblegum-96 board.
 
-_**[Device (96board)]**_
+Once you can access the U-Boot shell, execute `run create_gpt` command to
+reconstruct the gpt table and it will show
 
-Before doing anythingeverything, please make sure you have already install the serial console. If not, please install that use the following command.
+`Writing GPT: success!.` at the serial terminal.
 
-`$sudo apt-get install minicom`
+Execute `fastboot  usb` command to access fastboot mode. If the board is in
+fastboot-mode, you will see a device ID `18d1:0c02` by entering the command
+`lsusb` on host PC.
 
-Run another terminal and
+Now, proceed to the following sections to flash images to eMMC.
 
-`$sudo minicom -s`
+### 4) Flash kernel image
 
-In this case, we need to set the minicom,
-
-```shell
-Port: ttyUSB0
-Bps/Par/Bits: 115200
-Hardware control flow: No
-```
-
-While in the ADFU mode, Bubblegum96 board can be confirmed to be in “receiving mode” to accept commands from the Host-PC…  
-Please press `Enter` when system bootup, and it will show `“owl>”` prompt on serial console.
-
-### **Step 7:** Enter Fastboot mode
-
-_**[ Device (96board)]**_
-
-Execute `run create_gpt` to reconstruct the gpt table and it will show
-
-`Writing GPT: success!.`
-
-Execute `fastboot  usb` to access fastboot mode.
-If the board is in fastboot-mode, you will see a device ID `18d1:0c02` by entering the command `lsusb` on host PC.
-
-### **Step 8:** Flash kernel image
-
-The kernel image of 96board is located at boot.emmc.img
-
-_**[Host PC]**_
+The kernel image of 96board is contained in `boot.emmc.img` file.
 
 Please make sure you have already installed fastboot tool on your PC, if not, run the following command:
 
@@ -148,20 +64,18 @@ After that, continue flashing Bubblegum-96.
 
 **Note:** `boot.emmc.img` is a vfat format image, it contains kernel image, initramfs image, device tree blob, logo image used by u-boot
 
-### **Step 9:** Flash the root file system (rootfs)
+### 5) Flash the root file system (rootfs)
 
-The rootfs image of 96board is named as bubblegum-jessie_alip_20160224-12_r1.emmc.img
-The name could be different from what you have downloaded.
+The rootfs image of 96board is named as `bubblegum-jessie_alip_*.emmc.img`
 
-_**[Host PC]**_
-
-`$ sudo fastboot flash SYSTEM bubblegum-jessie_alip_20160224-12_r1.emmc.img`
+`$ sudo fastboot flash SYSTEM bubblegum-jessie_alip_*.emmc.img`
 
 **This step takes around 2 minutes or more depend on the image size.**
 
-### **Step 10:** Create bootloader.img and flash using fastboot
+### 6) Create bootloader.img and Flash using fastboot
 
-We need to flash the bootloader by fastboot. First we need to create the “BOOTLOADER” partition.
+We need to flash the bootloader onto eMMC by fastboot. First we need to create
+the `bootloader.img` image.
 
 Use the following commands on Host pc to create the bootloader.img:
 
@@ -171,9 +85,15 @@ $ dd if=/dev/zero of=bootloader.img bs=1M count=6
 # Place bootloader.bin to correct place.
 $ dd conv=notrunc if=bootloader.bin of=bootloader.img seek=4063 bs=512
 # Place u-boot-dtb.img to correct place.
-$dd conv=notrunc if=u-boot-dtb.img of=bootloader.img seek=6110 bs=512
-# Use fastboot to flash BOOTLOADER partition
-$sudo fastboot flash BOOTLOADER bootloader.img
+$ dd conv=notrunc if=u-boot-dtb.img of=bootloader.img seek=6110 bs=512
 ```
 
-Reboot.
+After preparing the `bootloader.img` image, use fastboot to flash BOOTLOADER
+partition.
+
+```shell
+$ sudo fastboot flash BOOTLOADER bootloader.img
+```
+
+Once all of the above mentioned processes are completed successfully, reboot
+the Bubblegum-96 board to boot the installed images!

--- a/consumer/bubblegum-96/support/README.md
+++ b/consumer/bubblegum-96/support/README.md
@@ -18,3 +18,5 @@ Please take advantage of the many Bubblegum-96 resources available to you throug
    - Students from the [University of California San Diego](https://ucsd.edu/) put together an "Internet of Things" (IoT) course focused around the 96Boards. It is free to audit, or you can purchase the specialization package for a cool certificate!
 - [Report a bug!](../../../Extras/Report_a_bug.md)
    - Instructions on how to report bugs for any of our 96Boards hardware and software, this includes the Bubblegum-96!
+- [Board Recovery](../installation/board-recovery.md)
+   - Bricked board? Many software issues can be fixed with a simple "board recovery"


### PR DESCRIPTION
Modify the fastboot instructions and add board recovery guide for
Bubblegum96.

Fixes: #122 

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>