### PR TITLE
dragonboard: move qdl info in its own document

### DIFF
--- a/consumer/dragonboard410c/installation/board-recovery.md
+++ b/consumer/dragonboard410c/installation/board-recovery.md
@@ -23,3 +23,57 @@ In most cases this will be your sure-fire way to recover your board from a softw
 ## Fastboot recovery
 
 In many cases, simply re-flashing the bootloader, boot image, and root file system, using the [fastboot method](README.md#fastboot-method) is enough. While the generic fastboot method might not always work due to certain complications, the sd card recovery image is always available (as seen above).
+
+## Using USB flashing tools
+
+Alternatively, the Dragonboard 410c can also be recovered/flashed over USB, using the Linaro QDL flashing tools. For more information about QDL, including installation instructions, please check this [guide](../../guides/qdl.md).
+
+### Connecting the board in USB flashing mode (aka EDL mode)
+
+In order to force the DB410c to boot on USB (EDL mode), you need to configure S6 switch properly. S6 is on the back of the board underneath the micro SD slot.
+
+* Power off the board and make sure no USB cable is plugged into the board
+* Set switch S6-1 to `ON`.
+* Connect the debug UART / serial console to your Linux PC, if not done already
+* Connect the micro USB cable (J4) between the Linux PC and the board
+* Open UART/serial console
+* Power on the device
+
+### Flashing the device
+
+Download and unzip the most recent bootloader package:
+
+http://snapshots.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragonboard-410c-bootloader-emmc-linux-*.zip
+
+Then run:
+
+    cd dragonboard-410c-bootloader-emmc-linux-*/
+    sudo <PATH to qdl>/qdl prog_emmc_firehose_8916.mbn rawprogram.xml patch.xml
+
+It should take a few seconds. And you should eventually get something like that:
+
+    ...
+    ...
+    Update Backup Header with CRC of Backup Header.
+    LOG: crc start sector 393215, over bytes 92
+    LOG: Patched sector 393215 with 8FDB38DF
+    LUN1 is now bootable device
+    LOG: Inside handlePower() - Requested POWER_RESET
+    LOG: Issuing bsp_target_reset() after 1 seconds, if this hangs, do you have WATCHDOG enabled?
+
+### Booting into fastboot
+
+If the flashing process succeeded, all the right bootloaders and partition table should have been set. And fastboot can now be used to flash Linux root file system. The first thing to try is to get into fastboot, to make sure the flashing completed properly.
+
+* Power off the board and make sure no USB cable is plugged into the board
+* Set Switch S6-1 to `OFF`.
+* Connect the debug UART / serial console to your Linux PC, if not done already
+* Connect the micro USB cable (J4) between the Linux PC and the board
+* Open UART/serial console
+* Power on the device
+
+You should some see debug traces on the console, and at the end something like:
+
+    ...
+    ...
+    fastboot: processing commands

--- a/consumer/dragonboard820c/installation/board-recovery.md
+++ b/consumer/dragonboard820c/installation/board-recovery.md
@@ -23,29 +23,7 @@ In many cases, simply re-flashing the bootloader, boot image, and root file syst
 
 ## Using USB flashing tools
 
-Alternatively, the Dragonboard 820c can also be recovered/flashed using USB. An open source tool that implements the Qualcomm Sahara protocol has been developed by Linaro. When booting from USB the internal SoC ROM code (also called PBL) implements the Sahara protocol to communicate with a PC host. After an initial setup phase, the Sahara protocol can be used to download a flashing programmer into the SoC internal memory, which implements the Firehose protocol. This protocol allows the host PC to send commands to write into the onboard storage (UFS). The USB flashing tool is only available for Linux hosts.
-
-### Get the Linux flashing tool
-
-    git clone https://git.linaro.org/landing-teams/working/qualcomm/qdl.git
-
-This is provided in source code, and it needs to be compiled locally. It uses libxml, so on Ubuntu/Debian you will need:
-
-    sudo apt-get install libxml2-dev
-
-To compile qdl project, it should be as simple as running make command in the top level folder of the project.
-
-### Make sure that ModemManager is not running
-
-Some Linux distributions come with ModemManager, a tool for configuring Mobile Broadband.
-When the dragonboard is connected in USB mode, it will be identified as a Qualcomm modem,
-and ModemManager will try to configure the device. This will interfere with the QDL flashing,
-so if you have ModemManager running, you need to disable it before connecting your dragonboard.
-If you are using a Linux distribution with systemd, ModemManager can be stopped by:
-
-    sudo systemctl stop ModemManager
-
-If you actually need ModemManager, you can start it again after the flashing is complete.
+Alternatively, the Dragonboard 820c can also be recovered/flashed over USB, using the Linaro QDL flashing tools. For more information about QDL, including installation instructions, please check this [guide](../../guides/qdl.md).
 
 ### Connecting the board in USB flashing mode (aka EDL mode)
 

--- a/consumer/guides/qdl.md
+++ b/consumer/guides/qdl.md
@@ -1,0 +1,43 @@
+---
+title: Qualcomm USB flashing tool
+
+
+permalink: /documentation/consumer/guides/qdl.md.html
+---
+# Qualcomm USB flashing tool
+
+Qualcomm MSM based devices contain a special mode of operation, called Emergency Download Mode (EDL). In this mode, the device identifies itself as Qualcomm HS-USB 9008 through USB, and can communicate with a PC host.  EDL is implemented by the SoC ROM code (also called PBL). The EDL mode itself implements the Qualcomm Sahara protocol, which accepts an OEM-digitally-signed programmer over USB. The programmer implements the Firehose protocol which allows the host PC to send commands to write into the onboard storage (eMMC, UFS).
+
+As open source tool (for Linux) that implements the Qualcomm Sahara and Firehose protocols has been developed by Linaro, and can be used for program (or unbrick) MSM based devices, such as Dragonboard 410c or Dragonboard 820c.
+
+# Get the Linux flashing tool
+
+    git clone https://git.linaro.org/landing-teams/working/qualcomm/qdl.git
+
+This is provided in source code, and it needs to be compiled locally. It uses libxml, so on Ubuntu/Debian you will need:
+
+    sudo apt-get install libxml2-dev
+
+To compile qdl project, it should be as simple as running make command in the top level folder of the project.
+
+# Make sure that ModemManager is not running
+
+Some Linux distributions come with ModemManager, a tool for configuring Mobile Broadband.
+When the dragonboard is connected in USB mode, it will be identified as a Qualcomm modem,
+and ModemManager will try to configure the device. This will interfere with the QDL flashing,
+so if you have ModemManager running, you need to disable it before connecting your dragonboard.
+If you are using a Linux distribution with systemd, ModemManager can be stopped by:
+
+    sudo systemctl stop ModemManager
+
+If you actually need ModemManager, you can start it again after the flashing is complete.
+
+# Flashing the device
+
+In order to flash the device , ensure the following:
+* the device is in EDL mode
+* you have access to the proper, device specific, digitally-signed ELF programmer
+* you have access to the Firehose XML commands to flash the device, and the corresponding blob/firmware
+
+For Dragonboard 410c, please refer to the [Dragonboard 410c recovery guide](../dragonboard410c/installation/board-recovery.md#using-usb-flashing-tools).
+For Dragonboard 820c, please refer to the [Dragonboard 820c recovery guide](../dragonboard820c/installation/board-recovery.md#using-usb-flashing-tools).


### PR DESCRIPTION
QDL is a flashing tool used for any QCOM SoC, it's not specific
DB820c (it's not even specific to Dragonboard, but any QC hardware),
so let's create a generic guide and link there instead.

Also:
* add USB flashing instructions for 410c, which were missing
* improve the QDL doc/wording

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>