### PR TITLE
common dragonboard and hikey documentation: index

### DIFF
--- a/consumer/README.md
+++ b/consumer/README.md
@@ -17,19 +17,27 @@ Select your Consumer Edition 96Boards device to access all product specific reso
 - [Compare 96Boards](guides/compare_96boards_ce.md)
 - [96Boards CE Extras](guides/)
 
+### Board Families
+
+<div style="overflow-x:scroll;" markdown="1">
+
+| Family                                           | Boards                                                 | Options                    |
+|:------------------------------------------------:|:------------------------------------------------------:|:--------------------------:|
+| <img src="https://i.imgur.com/tBDv5aG.jpg" data-canonical-src="https://i.imgur.com/tBDv5aG.jpg" width="426" height="240" /><br> **HiKey Family** | HiKey<br> HiKey960<br> HiKey970 | [Documentation](hikey-family/)<br> |
+| <img src="https://i.imgur.com/Uebk1I7.jpg" data-canonical-src="https://i.imgur.com/Uebk1I7.jpg" width="426" height="240" /><br> **DragonBoard Family** | DragonBoard410c<br> DragonBoard820c  | [Documentation](dragonboard-family/)<br> |
+</div>
+
+
+### Individual Boards
+
 <div style="overflow-x:scroll;" markdown="1">
 
 | 96Boards                                         | About                                                  | Options                    |
 |:------------------------------------------------:|:------------------------------------------------------:|:--------------------------:|
-| <img src="https://github.com/96boards/documentation/blob/master/consumer/hikey970/additional-docs/images/images-board/sd/hikey970-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/hikey970/additional-docs/images/images-board/sd/hikey970-front-sd.png?raw=true" width="200" height="130" /><br> **HiKey970** | Board based on the HI3670 Application Processor | [Documentation](hikey970/)<br> |
 | <img src="https://github.com/96boards/documentation/blob/master/consumer/chameleon96/additional-docs/images/images-board/chameleon96_top.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/chameleon96/additional-docs/images/images-board/chameleon96_top.png?raw=true" width="200" height="130" /><br> **Chameleon96** | Board based on the Intel Cyclone V SoC FPGA | [Documentation](chameleon96/)<br> |
 | <img src="https://github.com/96boards/documentation/blob/master/consumer/rock960/additional-docs/images/images-board/ROCK960_Front_SD.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/rock960/additional-docs/images/images-board/ROCK960_Front_SD.png?raw=true" width="200" height="130" /><br> **ROCK960** | Board based on Rockchip RK3399  | [Documentation](rock960/)<br> |
 | <img src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" width="200" height="130" /><br> **Ultra96** | Board based on Xilinx Zynq UltraScale+ MPSoC ZU3EG A484  | [Documentation](ultra96/)<br> |
-| <img src="https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/additional-docs/images/images-board/sd/dragonboard820c-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/additional-docs/images/images-board/sd/dragonboard820c-front-sd.png?raw=true" width="220" height="200" /><br> **DragonBoard 820c** | Board based on Qualcomm® Snapdragon™ 820E processor  | [Documentation](dragonboard820c/)<br> |
 | <img src="https://github.com/96boards/documentation/blob/master/consumer/imx7-96/additional-docs/images/images-board/iMX7-96-front.jpg?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/imx7-96/additional-docs/images/images-board/iMX7-96-front.jpg?raw=true" width="200" height="130" /><br> **i.MX7 96** | Board based on i.MX7 SoC  | [Documentation](imx7-96/)<br> |
-| <img src="https://github.com/96boards/documentation/blob/master/consumer/hikey960/additional-docs/images/images-board/sd/hikey960-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/hikey960/additional-docs/images/images-board/sd/hikey960-front-sd.png?raw=true" width="200" height="130" /><br> **HiKey960** | Board based on HiSilicon Kirin 960 processor  | [Documentation](hikey960/)<br> |
-| <img src="https://i.imgur.com/uKfxuu5.jpg" data-canonical-src="https://i.imgur.com/uKfxuu5.jpg" width="200" height="130" /><br> **HiKey** | Board based on HiSilicon Kirin 6220 processor  | [Documentation](hikey/)<br> |
-| <img src="https://i.imgur.com/4a5GXRd.png" data-canonical-src="https://i.imgur.com/4a5GXRd.png" width="200" height="130" /><br> **DragonBoard 410c** | Board based on Qualcomm® Snapdragon™ 410E processor  | [Documentation](dragonboard410c/)<br>|
 | <img src="https://i.imgur.com/u08Wb6U.png" data-canonical-src="https://i.imgur.com/u08Wb6U.png" width="200" height="130" /><br>**Bubblegum-96** | Board based on Actions Semi S900 Processor  | [Documentation](bubblegum-96/)<br> |
 <img src="https://i.imgur.com/ndacN8g.png" data-canonical-src="https://i.imgur.com/ndacN8g.png" width="200" height="130" /><br> **MediaTek X20** | Board based on MediaTek X20 Applications Processor  | [Documentation](mediatekx20/)<br> |
 | <img src="https://github.com/96boards/documentation/blob/master/consumer/mediatekx20pro/additional-docs/images/images-board/sd/mediatekx20pro-front-sd.jpg?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/mediatekx20pro/additional-docs/images/images-board/sd/mediatekx20pro-front-sd.jpg?raw=true" width="200" height="130" /><br> **MediaTek X20 Pro** | Board based on MediaTek X20 Applications Processor  | [Documentation](mediatekx20pro/)<br> |

--- a/consumer/dragonboard-family/README.md
+++ b/consumer/dragonboard-family/README.md
@@ -1,0 +1,22 @@
+---
+title: DragonBoard Documentation
+permalink: /documentation/consumer/dragonboard-family/
+---
+Welcome to the official documentation for Consumer Edition 96Boards, these documents are written by the [96Boards](https://www.96boards.org) team at [Linaro](http://www.linaro.org) with community contributions and links to third-party content.
+
+***
+
+## Contents - Start Here
+
+Select your Consumer Edition DragonBoard 96Boards device to access all product specific resources. You may also use the links below to compare, and explore a list of 96Boards Consumer Edition extras, this includes instructions for unique board configurations and fun projects.
+
+- [DragonBoard 96Boards Comparison](../guides/compare_96boards_ce.md)
+- [DragonBoard Generic Guides](../guides/)
+
+<div style="overflow-x:scroll;" markdown="1">
+
+| 96Boards                                         | About                                                  | Options                    |
+|:------------------------------------------------:|:------------------------------------------------------:|:--------------------------:|
+| <img src="https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/additional-docs/images/images-board/sd/dragonboard820c-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/additional-docs/images/images-board/sd/dragonboard820c-front-sd.png?raw=true" width="220" height="200" /><br> **DragonBoard 820c** | Board based on Qualcomm® Snapdragon™ 820E processor  | [Documentation](../dragonboard820c/)<br> |
+| <img src="https://i.imgur.com/4a5GXRd.png" data-canonical-src="https://i.imgur.com/4a5GXRd.png" width="200" height="130" /><br> **DragonBoard 410c** | Board based on Qualcomm® Snapdragon™ 410E processor  | [Documentation](../dragonboard410c/)<br>|
+</div>

--- a/consumer/hikey-family/README.md
+++ b/consumer/hikey-family/README.md
@@ -1,0 +1,23 @@
+---
+title: Hikey Family Documentation
+permalink: /documentation/consumer/hikey-family/
+---
+Welcome to the official documentation for Consumer Edition 96Boards, these documents are written by the [96Boards](https://www.96boards.org) team at [Linaro](http://www.linaro.org) with community contributions and links to third-party content.
+
+***
+
+## Contents - Start Here
+
+Select your Consumer Edition Hikey 96Boards device to access all product specific resources. You may also use the links below to compare, and explore a list of 96Boards Consumer Edition extras, this includes instructions for unique board configurations and fun projects.
+
+- [Compare Hikey 96Boards](../guides/compare_96boards_ce.md)
+- [96Boards Hikey Extras](../guides/)
+
+<div style="overflow-x:scroll;" markdown="1">
+
+| 96Boards                                         | About                                                  | Options                    |
+|:------------------------------------------------:|:------------------------------------------------------:|:--------------------------:|
+| <img src="https://github.com/96boards/documentation/blob/master/consumer/hikey970/additional-docs/images/images-board/sd/hikey970-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/hikey970/additional-docs/images/images-board/sd/hikey970-front-sd.png?raw=true" width="200" height="130" /><br> **HiKey970** | Board based on the HI3670 Application Processor | [Documentation](../hikey970/)<br> |
+| <img src="https://github.com/96boards/documentation/blob/master/consumer/hikey960/additional-docs/images/images-board/sd/hikey960-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/hikey960/additional-docs/images/images-board/sd/hikey960-front-sd.png?raw=true" width="200" height="130" /><br> **HiKey960** | Board based on HiSilicon Kirin 960 processor  | [Documentation](../hikey960/)<br> |
+| <img src="https://i.imgur.com/uKfxuu5.jpg" data-canonical-src="https://i.imgur.com/uKfxuu5.jpg" width="200" height="130" /><br> **HiKey** | Board based on HiSilicon Kirin 6220 processor  | [Documentation](../hikey/)<br> |
+</div>


### PR DESCRIPTION
This commit contains changes to the README.md index pages.
Device folders and guides remain where the were.

- Added dragonboard-family folder with README.md
- Added hikey-family folder with README.md

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>