### PR TITLE
consumer: guides: OE: Switch to sumo version

### DIFF
--- a/consumer/guides/open_embedded.md
+++ b/consumer/guides/open_embedded.md
@@ -100,7 +100,7 @@ To initialize your build environment, you need to run:
 
 ```shell
 $ mkdir oe-rpb && cd oe-rpb
-$ repo init -u https://github.com/96boards/oe-rpb-manifest.git -b morty
+$ repo init -u https://github.com/96boards/oe-rpb-manifest.git -b sumo
 $ repo sync
 $ source setup-environment <build folder>
 ```


### PR DESCRIPTION
For OE, since we support sumo in our oe-rpb-manifest it makes sense to
switch to sumo which is also the latest stable version of OpenEmbedded.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>