### PR TITLE
consumer: rock: add note for image download

### DIFF
--- a/consumer/rock/downloads/debian.md
+++ b/consumer/rock/downloads/debian.md
@@ -10,6 +10,15 @@ redirect_from: /documentation/consumer/rock960/downloads/debian.md.html
 
 ***
 
+> NOTE: default user name and password
+
+    username: rock
+    password: rock
+or
+
+    username: linaro
+    password: linaro
+
 ## SD Card/eMMC AIO image
 
 |   SD Card/eMMC AIO Image   |    Download     |

--- a/consumer/rock/downloads/ubuntu.md
+++ b/consumer/rock/downloads/ubuntu.md
@@ -10,6 +10,15 @@ redirect_from:  /documentation/consumer/rock960/downloads/ubuntu.md.html
 
 ***
 
+> NOTE: default user name and password
+
+    username: rock
+    password: rock
+or
+
+    username: linaro
+    password: linaro
+
 ## SD Card/eMMC image
 
 |   SD Card/eMMC Image   |    Download     |


### PR DESCRIPTION
Add default username and password on the download page for Ubuntu/Debian
image since some users ignore the readme in the image tar ball.

Fixes: #556

Signed-off-by: Jack Ma <jack@vamrs.com>