### PR TITLE
db410c: contribute: Fix the hyperlink to the ML

### DIFF
--- a/consumer/dragonboard/dragonboard410c/downloads/contribute.md
+++ b/consumer/dragonboard/dragonboard410c/downloads/contribute.md
@@ -17,7 +17,7 @@ This page provides instructions for developers willing to contribute to the Lina
 
 The following mailing list has been created to contributions:
 
-https://lists.96boards.org/mailman/listinfo/dragonboard
+[https://lists.96boards.org/mailman/listinfo/dragonboard](https://lists.96boards.org/mailman/listinfo/dragonboard)
 
 This is a public mailing open to any developer.
 


### PR DESCRIPTION
The Jekyll conversion doesn't auto-linkify this URL so let's force it to be a link.

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>