### PR TITLE
hikey960: debian: Warn that this is unreleased snapshot

### DIFF
--- a/consumer/hikey/hikey960/downloads/debian.md
+++ b/consumer/hikey/hikey960/downloads/debian.md
@@ -7,7 +7,11 @@ redirect_from:
 ---
 # Debian
 
-**Debian Linux** is a desktop/window or console (command line) based development environment comprised of some basic programs and utilities. Development can happen directly on the board, and within the OS. While applications and programs can be built directly on the board, they can also be built remotely and cross-compiled for the particular system.
+**Debian for Hikey960** is a console (command line) based development environment derived from Debian GNU/Linux and comprised of some basic programs and utilities. Development can happen directly on the board, and within the OS. While applications and programs can be built directly on the board, they can also be built remotely and cross-compiled for the particular system.
+
+Please take note that **Debian for Hikey960** is an **unreleased snapshot** (of an out-of-hours skunkworks project) rather than a fully featured release. Currently the snapshot does not support HDMI output and must be administered via [LS-UART1](https://www.96boards.org/pinout/). Visit the [96Boards forum](https://discuss.96boards.org/c/products/hikey960) to take part in the community and/or to learn about alternative kernel options the enable graphics.
+
+Warning: *All I/O signals on the Low Speed Connector use 1.8v TTL. Applying a higher voltage could damage your device so always ensure your UART adapter supports 1.8v operation **before** connecting it (mistakes can happen so we strongly recommend you check the adapter even if it came as part of a kit).*
 
 ***
 


### PR DESCRIPTION
As discussed on the forum currently the documentation does a poor
job of communicating the current status of Debian for Hikey960. This
page describes an unreleased skunkworks project that does not
support graphics out-of-the-box (which many users will expect) and
we need to make this clear through something much more obvious than
the server the files are downloaded from!

Additional, since this is one of the few bits of software for 96Boards
which requires a UART we also add a warning about checking the
UART adapter is suitable before connecting it.

Reported-by: Torbjörn Granlund
Link: https://discuss.96boards.org/t/6310
Fixes: #619
Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>