### PR TITLE
fixes: couple of fixes for hikey and hk970

### DIFF
--- a/consumer/hikey/README.md
+++ b/consumer/hikey/README.md
@@ -10,8 +10,6 @@ Welcome to the official documentation for Consumer Edition 96Boards, these docum
 
 Select your Consumer Edition Hikey 96Boards device to access all product specific resources. You may also use the links below to compare, and explore a list of 96Boards Consumer Edition extras, this includes instructions for unique board configurations and fun projects.
 
-- HiKey Generic Guides
-
 <div style="overflow-x:scroll;" markdown="1">
 
 | 96Boards                                         | About                                                  | Options                    |

--- a/consumer/hikey/hikey970/build/aosp.md
+++ b/consumer/hikey/hikey970/build/aosp.md
@@ -25,6 +25,8 @@ It might take quite a bit of time to fetch the entire AOSP source code!
 
 # Copy Pre-Built Kernel Binaries
 
+- [Build the Kernel](./linux-kernel.md)
+
 - Copy kirin970-hikey970.dtb.dtb (arch/arm64/boot/dts/hisilicon/ kirin970-hikey970.dtb) to the device/linaro/hikey-kernel directory as file: kirin970-hikey970.dtb-4.9
 
 - Copy the Image file (arch/arm64/boot/Image.gz-dtb) to the device/linaro/hikey-kernel directory as file: Image.gz-hikey970-4.9

--- a/consumer/hikey/hikey970/build/linux-kernel.md
+++ b/consumer/hikey/hikey970/build/linux-kernel.md
@@ -9,7 +9,7 @@ redirect_from:  /documentation/consumer/hikey970/build/linux-kernel.md.html
 This page provides the instructions for building and deploying linux
 kernel on HiKey970 from x86 host machine.
 
-**This instruction is to be used only after building [AOSP](aosp.md)**
+**This instruction is to be used only after or during building [AOSP](aosp.md)**
 
 ## Get Linux Kernel Source
 


### PR DESCRIPTION
- Removed mention of "Common Hikey Guides" as they don't exist
- fixes #624

- Added link to kernel build guide for AOSP build guide
- fixes #621

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>