### PR TITLE
consumer/sophon-edge: Added links to build instructions

### DIFF
--- a/consumer/sophon-edge/build/README.md
+++ b/consumer/sophon-edge/build/README.md
@@ -5,4 +5,5 @@ permalink: /documentation/consumer/sophon-edge/build/
 
 # Build from Source
 
-Coming Soon...
+- [Build SDK](https://github.com/BM1880-BIRD/bm1880-system-sdk)
+- [Build Program](https://github.com/BM1880-BIRD/bm1880-ai-demo-program)


### PR DESCRIPTION
Signed-off-by: Robert Wolff <robert.wolff@linaro.org>