### PR TITLE
link fixes

### DIFF
--- a/consumer/dragonboard/dragonboard410c/downloads/debian.md
+++ b/consumer/dragonboard/dragonboard410c/downloads/debian.md
@@ -32,7 +32,7 @@ redirect_from:
 
 | Bootloader                                                                                                                             |
 |:---------------------------------------------------------------------------------------------------------------------------------------|
-| [Download](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragonboard410c_bootloader_emmc_linux-*.zip)       |
+| [Download](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragonboard-410c_bootloader_emmc_linux-*.zip)       |
 | [Release Notes](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/)                                             |
 
 | Boot image                                                                                                                             |

--- a/consumer/dragonboard/dragonboard410c/downloads/open-embedded.md
+++ b/consumer/dragonboard/dragonboard410c/downloads/open-embedded.md
@@ -16,7 +16,7 @@ redirect_from:
 
 | Bootloader                                                                                                                              |
 |:----------------------------------------------------------------------------------------------------------------------------------------|
-| [Download](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragonboard410c_bootloader_emmc_linux-*.zip)        |
+| [Download](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragonboard-410c_bootloader_emmc_linux-*.zip)        |
 | [Release Notes](http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/)      |
 
 Choose between RPB and RPB-Wayland. You will need to download the "boot image" and your choice of "Desktop" or "Console" rootfs.

--- a/consumer/rock/downloads/ubuntu.md
+++ b/consumer/rock/downloads/ubuntu.md
@@ -73,6 +73,6 @@ This image can be flashed to eMMC from USB or write and run on a SD card. Contin
 
 |   Rootfs image    |    Download                    |
 |:------------------|:----------------------------------|
-| Ubuntu 16.04 Server rootfs arm64     | [ubuntu_16.04_server_rootfs.img.gz](https://dl.vamrs.com/products/rock960c/images/ubuntu/ubuntu_server_16.04_arm64_rootfs_20171108.img.gz)                          |
+| Ubuntu 16.04 Server rootfs arm64     | [ubuntu_16.04_server_rootfs.img.gz](https://dl.vamrs.com/products/rock960c/images/ubuntu/partitions/rootfs/ubuntu_server_16.04_arm64_rootfs_20171108.ext4.gz)                          |
 
 Continue to [Installation page](../installation)


### PR DESCRIPTION
The following links are fixed:

/documentation/consumer/dragonboard/dragonboard410c/downloads/debian.md.html:
http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragonboard410c_bootloader_emmc_linux-*.zip [404]

/documentation/consumer/dragonboard/dragonboard410c/downloads/open-embedded.md.html:
http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragonboard410c_bootloader_emmc_linux-*.zip [404]

/documentation/consumer/rock/downloads/ubuntu.md.html:
https://dl.vamrs.com/products/rock960c/images/ubuntu/ubuntu_server_16.04_arm64_rootfs_20171108.img.gz [404]

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>