### PR TITLE
consumer: Remove the use of debug UART during recovery

### DIFF
--- a/consumer/dragonboard/dragonboard820c/installation/board-recovery.md
+++ b/consumer/dragonboard/dragonboard820c/installation/board-recovery.md
@@ -34,9 +34,7 @@ In order to force the DB820c to boot on USB (EDL mode), you need to configure S1
 
 * Power off the board and make sure no USB cable is plugged into the board
 * Set switch S1 to `ON,OFF,OFF,ON`. If you have a P1 board (very unlikely) you need to set to `ON,ON,OFF,ON`.
-* Connect the debug UART / serial console to your Linux PC, if not done already
 * Connect the micro USB cable (J4) between the Linux PC and the board
-* Open UART/serial console
 * Power on the device
 
 ### Flashing the device
@@ -50,7 +48,8 @@ Then run:
     cd dragonboard-820c-bootloader-ufs-linux-42.zip/
     sudo <PATH to qdl>/qdl prog_ufs_firehose_8996_ddr.elf rawprogram.xml patch.xml
 
-It should take a few seconds. And you should eventually get something like that:
+It should take a few seconds. And you should eventually get something like below
+from QDL stdout:
 
     ...
     ...
@@ -85,14 +84,12 @@ If the flashing process succeeded, all the right bootloaders and partition table
 
 * Power off the board and make sure no USB cable is plugged into the board
 * Set Switch S1 to `OFF,OFF,OFF,OFF`. If you have a P1 board (very unlikely) you may need to use `OFF,ON,OFF,OFF`.
-* Connect the debug UART / serial console to your Linux PC, if not done already
 * Connect the micro USB cable (J4) between the Linux PC and the board
-* Open UART/serial console
 * Power on the device
 
-You should some see debug traces on the console, and at the end something like:
+Execute below command on the PC to confirm that the board has entered fastboot mode:
 
-    S- QC_IMAGE_VERSION_STRING=BOOT.XF.1.0-00301
-    ...
-    ...
-    fastboot: processing commands
+```shell
+$ sudo fastboot devices
+01234567	fastboot
+```

--- a/consumer/hikey/hikey960/installation/board-recovery.md
+++ b/consumer/hikey/hikey960/installation/board-recovery.md
@@ -65,52 +65,6 @@ Jumper Pin 5-6 = DIP switch 3                     |
 Since we are going to flash the bootloader binaries, we need to boot into
 **recovery mode** as mentioned above.
 
-### Connect Hikey960 Serial Console
-
-Follow any one of the below steps for setting up the console.
-
-#### Ser2Net
-
-Install ser2net using below command:
-
-```shell
-$ sudo apt-get install ser2net
-```
-
-Configure ser2net:
-
-```shell
-$ sudo vi /etc/ser2net.conf
-```
-
-Append one line for serial-over-USB in below:
-
-```shell
-2004:telnet:0:/dev/ttyUSB0:115200 8DATABITS NONE 1STOPBIT banner
-```
-
-Open the console.
-
-```shell
-$ telnet localhost 2004
-```
-
-And you could open the console remotely, too.
-
-#### Picocom
-
-Install picocom using the below command: 
-
-```shell
-$ sudo apt-get install picocom
-```
-
-Open the console:
-
-```shell
-$ picocom /dev/ttyUSB0 -b 115200 -f x
-```
-
 ### Connect the HiKey960 power supply to the board.
 
 Since USB does **NOT** power the HiKey960 board, you must use an external
@@ -127,17 +81,17 @@ $ dmesg
 
 ### Flash the recovery binaries
 
-Make sure the modem interface is in the right ttyUSB as previously suggested. In this example, use ttyUSB1:
+Make sure the modem interface is in the right ttyUSB as previously suggested. In this example, `ttyUSB0` is used:
 
 ```
-$ sudo ./hikey_idt -c config -p /dev/ttyUSB1
+$ sudo ./hikey_idt -c config -p /dev/ttyUSB0
 ```
 
 You should be able to see the following output after executing the tool:
 
 ```
 Config name: config
-Port name: /dev/ttyUSB1
+Port name: /dev/ttyUSB0
 0: Image: sec_usb_xloader.img Downalod Address: 0x20000
 1: Image: sec_uce_boot.img Downalod Address: 0x6a908000
 2: Image: l-loader.bin Downalod Address: 0x1ac00000

--- a/consumer/hikey/hikey970/installation/board-recovery.md
+++ b/consumer/hikey/hikey970/installation/board-recovery.md
@@ -129,11 +129,11 @@ $ dmesg
 
 Now, move into the `tools-images-hikey970` directory and execute the recovery script.
 Make sure the modem interface is in the right ttyUSB as previously suggested. In this
-example, use ttyUSB1:
+example, `ttyUSB0` is used:
 
 ```
 $ cd tools-images-hikey970
-$ sudo python hisi-idt.py -d /dev/ttyUSB1 --img1 ./sec_usb_xloader.img --img2 ./sec_usb_xloader2.img --img3 ./l-loader.bin
+$ sudo python hisi-idt.py -d /dev/ttyUSB0 --img1 ./sec_usb_xloader.img --img2 ./sec_usb_xloader2.img --img3 ./l-loader.bin
 ```
 
 > Note: This script only works with Python2.7
@@ -142,7 +142,7 @@ You should see the following output on PC after executing the above command:
 
 ```
 +----------------------+
-(' Serial: ', '/dev/ttyUSB1')
+(' Serial: ', '/dev/ttyUSB0')
 (' Image1: ', './sec_usb_xloader.img')
 (' Image2: ', './sec_usb_xloader2.img')
 +----------------------+


### PR DESCRIPTION
Debug UART is not necessary when recovering a CE board. Also, the
current recovery instructions doesn't make use of debug console output
for monitoring the recovery process. Hence, remove the references to
debug UART from recovery instructions and use `ttyUSB0` as the recovery
port.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>