### PR TITLE
consumer: hikey: Use updated kernel tree

### DIFF
--- a/consumer/hikey/hikey620/build/linux-kernel.md
+++ b/consumer/hikey/hikey620/build/linux-kernel.md
@@ -37,8 +37,7 @@ $ sudo apt install build-essential fakeroot bc kmod cpio libssl-dev bison flex
 ## Get Linux Kernel Source
 
 ```shell
-$ git clone https://github.com/suihkulokki/linux.git
-$ git checkout -t origin/hikey-v4.15
+$ git clone https://git.linaro.org/people/manivannan.sadhasivam/hikey.git
 ```
 
 ## Build the Linux Kernel


### PR DESCRIPTION
We have switched to a new kernel tree for the latest debian release. Hence,
use the same in the kernel build guide.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>