### PR TITLE
wistrio: Add installation instructions for Linux host

### DIFF
--- a/iot/wistrio/installation/README.md
+++ b/iot/wistrio/installation/README.md
@@ -4,36 +4,5 @@ permalink: /documentation/iot/wistrio/installation/
 ---
 # Installation
 
-> Windows Only
-
-Make sure to download the following from the [Downloads Page](../downloads):
-- CP210x Windows Driver
-- STM32 Flasher aka Demonstrator
-
-
-
-1. Install the “CP210x_windows_Drivers” driver
-  - Unzip the CP210x Driver file, and run the installer
-  - Connect the WisTrio Board, Windows should now look for the correct drivers and install them.
-  - Note down the COM port, In most cases it should be COM3
-2. Install the STM32 Flash Loader Demonstrator
-3. Connect the BOOT jumper:
-  - The bootpin of the board needs to be raised to 3.3V when upgrading, so
-you need to connect the BOOT0 and VDD pin of J12 by using a jumper.
-  - Also, make sure that the RX pin of J25 is connected to the RXCP pin.
-4. Start Upgrading the Firmware
-  - Open the STM32 Flash Demonstrator Program
-    - Select the COM Port
-    - Set BaudRate to 115200
-    - Click Next
-  - Press reset button on the WisTrio Board
-    - You should see the traffic light turn green
-    - Click Next
-  - Select "STM32L1_Cat2-128K" as Target
-    - Click Next
-  - Select “Download to device” then navigate to location of bin file.
-    - Click “Next”
-    - This will start the download process
-5. Reset:
-  - After finishing the download, close the Demonstrator program, disconnect the
-RAK5205 and remove the jumper of J12.
+1. [Linux](./linux.md)
+2. [Windows](./windows.md)

--- a/iot/wistrio/installation/linux.md
+++ b/iot/wistrio/installation/linux.md
@@ -1,0 +1,39 @@
+---
+title: WisTrio Installation for Linux
+permalink: /documentation/iot/wistrio/installation/linux.md.html
+---
+
+# Linux
+
+Following instructions specifies how to flash the firmware onto WisTrio board
+from a Linux host machine:
+
+1. Install `stm32flash` tool
+
+```shell
+$ git clone https://git.code.sf.net/p/stm32flash/code stm32flash-code
+$ cd stm32flash-code
+$ make
+$ sudo make install
+```
+2. Download the firmware from [Git repo](https://github.com/RAKWireless/RAK5205-WisTrio-LoRa/tree/master/doc/Firmware).
+
+3. Trigger ROM bootloader
+   - Connect 96Boards WisTrio to your Linux PC using, USB-Micro to USB-A cable.
+   - ROM bootloader can be triggered by the following pattern:
+       - Connect BOOT0 to VDD (link pin 1 and 2 on J12)
+       - Press and release the RST button
+
+4. Flash the firmware onto WisTrio
+```shell
+$ sudo stm32flash -b 115200 -w ./Firmware/RAK811_HF_trackerboard_V2.0.0.6.bin -v -g 0x08000000 /dev/ttyUSB0
+```
+
+> Note: `/dev/ttyUSB0` is the serial port exposed by WisTrio
+
+5. Once the firmware is flashed, unlink J12 and connect to the WisTrio serial port using minicom
+```shell
+$ sudo minicom -D /dev/ttyUSB0
+```
+> Note: For getting the AT command response, Local echo needs to be turned ON. On minicom,
+>       this can be achieved by `Ctrl + A, E`. After entering the AT commands, press `Ctrl + J`.

--- a/iot/wistrio/installation/windows.md
+++ b/iot/wistrio/installation/windows.md
@@ -1,0 +1,39 @@
+---
+title: WisTrio Installation for Windows
+permalink: /documentation/iot/wistrio/installation/windows.md.html
+---
+
+# Windows
+
+Following instructions specifies how to flash the firmware onto WisTrio board
+from a Windows host machine:
+
+Make sure to download the following from the [Downloads Page](../downloads):
+- CP210x Windows Driver
+- STM32 Flasher aka Demonstrator
+
+1. Install the “CP210x_windows_Drivers” driver
+  - Unzip the CP210x Driver file, and run the installer
+  - Connect the WisTrio Board, Windows should now look for the correct drivers and install them.
+  - Note down the COM port, In most cases it should be COM3
+2. Install the STM32 Flash Loader Demonstrator
+3. Connect the BOOT jumper:
+  - The bootpin of the board needs to be raised to 3.3V when upgrading, so
+you need to connect the BOOT0 and VDD pin of J12 by using a jumper.
+  - Also, make sure that the RX pin of J25 is connected to the RXCP pin.
+4. Start Upgrading the Firmware
+  - Open the STM32 Flash Demonstrator Program
+    - Select the COM Port
+    - Set BaudRate to 115200
+    - Click Next
+  - Press reset button on the WisTrio Board
+    - You should see the traffic light turn green
+    - Click Next
+  - Select "STM32L1_Cat2-128K" as Target
+    - Click Next
+  - Select “Download to device” then navigate to location of bin file.
+    - Click “Next”
+    - This will start the download process
+5. Reset:
+  - After finishing the download, close the Demonstrator program, disconnect the
+RAK5205 and remove the jumper of J12.


### PR DESCRIPTION
Add installation instructions for Linux host and split the Windows instructions.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>