### PR TITLE
rock960: installation: Link to Troubleshooting section

### DIFF
--- a/consumer/rock/installation/linux-mac-rkdeveloptool.md
+++ b/consumer/rock/installation/linux-mac-rkdeveloptool.md
@@ -92,6 +92,9 @@ Run the following command to download and run the mini loader to init DRAM and p
 
     rkdeveloptool db rk3399_loader_v1.08.106.bin
 
+> Note: If the above command throws any error, please follow the
+> [Troubleshooting](#Troubleshooting) section to resolve it.
+
 #### **Step 5**: Flash images onto ROCK960 eMMC and reboot
 
 Write the image to eMMC with the following command and address:
@@ -134,7 +137,13 @@ When the board is in maskrom mode, flash the partitions with the following comma
 
 After run any command of rkdeveloptool, it keeps complaining
 
-    "Creating Comm Object failed!"
+```
+Creating Comm Object failed!
+```
+or
+```
+not found any devices!
+```
 
 It's permission issue, you can run the following command to set the udev rule:
 


### PR DESCRIPTION
Since the `rkdeveloptool` can fail at the first instruction itself,
it makese sense to mention the link to the Troubleshooting section there
itself. While adding the link, let's also include the commonly encountered
error message.

Fixes: #748

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>