### PR TITLE
Update linux-kernel.md

### DIFF
--- a/consumer/rock/build/linux-kernel.md
+++ b/consumer/rock/build/linux-kernel.md
@@ -44,7 +44,7 @@ $ git checkout -t origin/rock960-4.4-dev
 
 ```shell
 $ export ARCH=arm64
-$ export CROSS_COMPILE=<path-to-cross-compiler>/aarch64-linux-gnu-gcc-
+$ export CROSS_COMPILE=<path-to-cross-compiler>/aarch64-linux-gnu-
 ```
 **Note:** Replace `path-to-cross-compiler` in the above command with the location
           where you have extracted the toolchain


### PR DESCRIPTION
The CROSS_COMPILE env variable is used as a prefix for any tool used during compilation. It's not the compiler itself.

Signed-off-by: Willy Wolff <willy.mh.wolff.ml@gmail.com>