### PR TITLE
Broken gcc toolchain link fix

### DIFF
--- a/consumer/dragonboard/dragonboard410c/build/kernel.md
+++ b/consumer/dragonboard/dragonboard410c/build/kernel.md
@@ -16,7 +16,7 @@ on Dragonboard410c from x86 host machine.
 You need to download the correct GCC toolchain depending your host/target architecture. Usually host is a standard Intel x86-64 computer, target is the Dragonboard which is AARCH64. <a href="https://www.linaro.org/downloads"> Linaro </a>  provides linux host binaries.
 ```shell
        $ mkdir toolchain
-       $ wget releases.linaro.org/components/toolchain/binaries/latest/aarch64-linux-gnu/gcc-*-x86_64_aarch64-linux-gnu.tar.xz
+       $ wget releases.linaro.org/components/toolchain/binaries/latest-7/aarch64-linux-gnu/gcc-*-x86_64_aarch64-linux-gnu.tar.xz
        $ tar -xf gcc-*-x86_64_aarch64-linux-gnu.tar.xz -C ./toolchain --strip-components=1
 ```
 


### PR DESCRIPTION
Download toolchain link is broken. At linaro toolchain site as of now I can see GCC 7 is from Linaro and GCC 8 points to ARM. so I suggest to take gcc 7 link from Linaro site.