### PR TITLE
Update qdl.md to include libudev dependancy

### DIFF
--- a/consumer/guides/qdl.md
+++ b/consumer/guides/qdl.md
@@ -14,9 +14,9 @@ As open source tool (for Linux) that implements the Qualcomm Sahara and Firehose
 
     git clone https://git.linaro.org/landing-teams/working/qualcomm/qdl.git
 
-This is provided in source code, and it needs to be compiled locally. It uses libxml, so on Ubuntu/Debian you will need:
+This is provided in source code, and it needs to be compiled locally. It uses libxml and libudev, so on Ubuntu/Debian you will need:
 
-    sudo apt-get install libxml2-dev
+    sudo apt-get install libxml2-dev libudev-dev
 
 To compile qdl project, it should be as simple as running make command in the top level folder of the project.
 


### PR DESCRIPTION
The build also depends on libudev-dev without which the compiler would return following error.

qdl.c:43:10: fatal error: libudev.h: No such file or directory
 #include <libudev.h>