### PR TITLE
documentation fixes

### DIFF
--- a/consumer/dragonboard/dragonboard410c/guides/DragonBoard-Qt-Setup.md
+++ b/consumer/dragonboard/dragonboard410c/guides/DragonBoard-Qt-Setup.md
@@ -49,7 +49,7 @@ rsync -avz linaro@10.42.0.61:/usr/lib sysroot/usr
 ```
 We need to make the symlinks in the sysroot to be relative. Download this script and run it with the "sysroot" directory as the argument.
 ```
-wget https://raw.githubusercontent.com/riscv/riscv-poky/priv-1.10/scripts/sysroot-relativelinks.py
+wget https://raw.githubusercontent.com/Kukkimonsuta/rpi-buildqt/master/scripts/utils/sysroot-relativelinks.py
 chmod +x sysroot-relativelinks.py
 ./sysroot-relativelinks.py sysroot
 ```
@@ -57,14 +57,14 @@ chmod +x sysroot-relativelinks.py
 **[Host PC]**
 Download the Linaro cross-compile toolchain
 ```
-wget https://releases.linaro.org/components/toolchain/binaries/latest/aarch64-linux-gnu/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu.tar.xz
+wget https://releases.linaro.org/components/toolchain/binaries/7.3-2018.05/aarch64-linux-gnu/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu.tar.xz
 tar -xf gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu.tar.xz
 ```
 ### Download Qt5
 **[Host PC]**
 We are going to clone the Qt5 super module and download the modules we need (you can download other modules if you want).
 ```
-git clone https://code.qt.io/qt/qt5.git
+git clone https://github.com/qt/qt5
 cd qt5
 ./init-repository -f --module-subset=default,-qtwebkit,-qtwebkit-examples,-qtwebengine
 ```

--- a/consumer/dragonboard/dragonboard845c/installation/README.md
+++ b/consumer/dragonboard/dragonboard845c/installation/README.md
@@ -1,12 +1,12 @@
 ---
-title: Installation for DragonBoard 845c
+title: Installation for DragonBoard 845
 permalink: /documentation/consumer/dragonboard/dragonboard845c/installation/
 ---
 # Installation
 
-Stand alone DragonBoard 410c will ship with the Android image. If the DragonBoard 410c is purchased as part of a kit, it may have a different pre-loaded operating system.
+Stand alone DragonBoard 845 will ship with the Android image. If the DragonBoard 845 is purchased as part of a kit, it may have a different pre-loaded operating system.
 
-This guide will help you choose and install an operating system and installation method on your DragonBoard 410c.
+This guide will help you choose and install an operating system and installation method on your DragonBoard 845.
 
 To appropriately follow this installation guide you will need to:
 
@@ -22,9 +22,9 @@ Fastboot is supported by the board and can be used for installs. This is for adv
 
 This method requires the following hardware:
 
-- DragonBoard 410c with power supply
+- DragonBoard 845 with power supply
 - Host machine (Linux, Mac OS X, or Windows)
-- USB to microUSB cable
+- USB to USB Type C cable
 - USB Mouse and/or keyboard (not required to perform flash)
 - HDMI Monitor with full size HDMI cable (not required to perform flash)
 

--- a/consumer/rock/downloads/debian.md
+++ b/consumer/rock/downloads/debian.md
@@ -28,13 +28,15 @@ redirect_from: /documentation/consumer/rock960/downloads/debian.md.html
 
 |   SD Card/eMMC AIO GPT Image   |    Download     |
 |:------------------|:------------------------------------|
-|All-in-one GPT image with bootloader/kernel/rootfs     |[Debian Stretch Desktop armhf](https://dl.vamrs.com/products/rock960/images/debian/rock960_debian_stretch_desktop_armhf_20180115.tar.gz)                             |
+| All-in-one GPT image with bootloader/kernel/rootfs     | [Debian Stretch Desktop armhf](https://dl.vamrs.com/products/rock960/images/debian/rock960_debian_stretch_desktop_armhf_20180115.tar.gz) |
+
 
 ### For ROCK960 model C
 
 |   SD Card/eMMC AIO GPT Image   |    Download     |
 |:------------------|:------------------------------------|
-|All-in-one GPT image with bootloader/kernel/rootfs     |[Debian Stretch Desktop armhf](https://dl.vamrs.com/products/rock960c/images/debian/rock960c_debian_stretch_lxde_armhf_20180920.tar.gz)                             |
+| All-in-one GPT image with bootloader/kernel/rootfs     | [Debian Stretch Desktop armhf](https://dl.vamrs.com/products/rock960c/images/debian/rock960c_debian_stretch_lxde_armhf_20180920.tar.gz) |
+
 
 This image can be flashed to eMMC from USB or write and run on a SD card. Continue to [Installation page](../installation)
 


### PR DESCRIPTION
- rock960 downloads table fix. fixes #794
- db845: fix installation page mentioning 410c instead of 845. fixes #789
- db410c: QT5 installation link fixes. fixes #717

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>