### PR TITLE
hikey: Fix links to latest UEFI binaries

### DIFF
--- a/consumer/hikey/hikey620/downloads/debian.md
+++ b/consumer/hikey/hikey620/downloads/debian.md
@@ -25,10 +25,10 @@ redirect_from:
 
 |   Bootloader    |     
 |:----------------------------:|
-| [l-loader.bin](http://builds.96boards.org/snapshots/reference-platform/components/uefi-staging/latest/hikey/debug/l-loader.bin)  |  
-|  [fip.bin](http://builds.96boards.org/snapshots/reference-platform/components/uefi-staging/latest/hikey/debug/fip.bin)           |  
-| [nvme.img](http://builds.96boards.org/snapshots/reference-platform/components/uefi-staging/latest/hikey/debug/nvme.img)          |
-| [ptable-linux-4g.img](http://builds.96boards.org/snapshots/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-4g.img) or [ptable-linux-8g.img](http://builds.96boards.org/snapshots/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-8g.img)     |
+| [l-loader.bin](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/l-loader.bin)  |  
+|  [fip.bin](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/fip.bin)           |  
+| [nvme.img](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/nvme.img)          |
+| [ptable-linux-4g.img](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-4g.img) or [ptable-linux-8g.img](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-8g.img)     |
 
 |   Boot image    |    [Download](http://snapshots.linaro.org/96boards/hikey/linaro/debian/latest/boot-linaro-stretch-developer-hikey-*.img.gz)    |
 |:------------------|:-----------------------|

--- a/consumer/hikey/hikey620/installation/board-recovery.md
+++ b/consumer/hikey/hikey620/installation/board-recovery.md
@@ -16,23 +16,23 @@ For most users a board can be “recovered” from a software failure by reloadi
 
 #### Choose your Operating System and download the following files
 
-- **Build Folders [UEFI debug](http://builds.96boards.org/snapshots/reference-platform/components/uefi-staging/latest/hikey/debug/)**
+- **Build Folders [UEFI debug](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/)**
 
 |  Debian                      |
 |:----------------------------:|
-| [recovery.bin](https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/recovery.bin)  |  
-| [l-loader.bin](https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/l-loader.bin)  |  
-|  [fip.bin](https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/fip.bin)           |  
-| [ptable-linux-4g.img](https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-4g.img) or [ptable-linux-8g.img](https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-8g.img)     |
+| [recovery.bin](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/recovery.bin)  |  
+| [l-loader.bin](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/l-loader.bin)  |  
+|  [fip.bin](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/fip.bin)           |  
+| [ptable-linux-4g.img](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-4g.img) or [ptable-linux-8g.img](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-8g.img)     |
 
-- **Build Folders [UEFI release](http://builds.96boards.org/snapshots/reference-platform/components/uefi-staging/latest/hikey/debug/)**
+- **Build Folders [UEFI release](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/)**
 
 |  Debian                      |
 |:----------------------------:|
-| [recovery.bin](https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/recovery.bin)  |  
-| [l-loader.bin](https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/l-loader.bin)  |  
-|  [fip.bin](https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/fip.bin)           |  
-| [ptable-linux-4g.img](https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-4g.img) or [ptable-linux-8g.img](https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-8g.img)     |
+| [recovery.bin](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/recovery.bin)  |  
+| [l-loader.bin](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/l-loader.bin)  |  
+|  [fip.bin](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/fip.bin)           |  
+| [ptable-linux-4g.img](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-4g.img) or [ptable-linux-8g.img](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-8g.img)     |
 
 You can do this from your browser(above links) or from the command prompt(below commands):
 
@@ -40,19 +40,19 @@ For a full recovery you will need: **recovery.bin**, **l-loader.bin**, **fip.bin
 
 - Debug Builds
 ```shell
-$ wget https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/recovery.bin
-$ wget https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/l-loader.bin
-$ wget https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/fip.bin
-$ wget https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-4g.img
-$ wget https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-8g.img
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/recovery.bin
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/l-loader.bin
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/fip.bin
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-4g.img
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-8g.img
 ```
 - Release Builds
 ```shell
-$ wget https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/release/recovery.bin
-$ wget https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/release/l-loader.bin
-$ wget https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/release/fip.bin
-$ wget https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/release/ptable-linux-4g.img
-$ wget https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/release/ptable-linux-8g.img
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/release/recovery.bin
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/release/l-loader.bin
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/release/fip.bin
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/release/ptable-linux-4g.img
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/release/ptable-linux-8g.img
 ```
 
 #### Make sure fastboot is set up on host computer
@@ -97,12 +97,12 @@ $ dmesg
 
 #### Download hisi-idt.py "download tool" for the HiKey
 
-[hisi-idt.py](https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/debug/hisi-idt.py) is the download tool for the HiKey. This is used to install the bootloader as follows:
+[hisi-idt.py](https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/hisi-idt.py) is the download tool for the HiKey. This is used to install the bootloader as follows:
 
 This script can also be downloaded using the wget command in your commandline:
 
 ```
-$ wget https://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey/release/hisi-idt.py
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/release/hisi-idt.py
 ```
 
 #### Run the script to initially prepare fastboot

--- a/consumer/hikey/hikey620/installation/linux-fastboot.md
+++ b/consumer/hikey/hikey620/installation/linux-fastboot.md
@@ -65,9 +65,9 @@ $ gunzip boot-linaro-stretch-developer-hikey.img.gz
 $ wget http://snapshots.linaro.org/96boards/hikey/linaro/debian/latest/rootfs-linaro-stretch-developer-hikey-*.img.gz -O rootfs-linaro-stretch-developer-hikey.img.gz
 $ gunzip rootfs-linaro-stretch-developer-hikey.img.gz
 # PTABLE IMAGE FOR 8GB EMMC
-$ wget http://builds.96boards.org/snapshots/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-8g.img
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-8g.img
 # PTABLE IMAGE FOR 4GB EMMC
-$ wget http://builds.96boards.org/snapshots/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-4g.img
+$ wget https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey/debug/ptable-linux-4g.img
 ```
 - Flash eMMC
 ```shell

--- a/consumer/hikey/hikey960/downloads/debian.md
+++ b/consumer/hikey/hikey960/downloads/debian.md
@@ -29,9 +29,9 @@ Warning: *All I/O signals on the Low Speed Connector use 1.8v TTL. Applying a hi
 
 |   Bootloader    |
 |:----------------------------:|
-| [l-loader.bin](http://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey960/debug/l-loader.bin)     |
-|  [fip.bin](http://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey960/debug/fip.bin)              |
-| [prm_ptable.img](http://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey960/debug/prm_ptable.img) |
+| [l-loader.bin](http://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey960/debug/l-loader.bin)     |
+|  [fip.bin](http://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey960/debug/fip.bin)              |
+| [prm_ptable.img](http://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey960/debug/prm_ptable.img) |
 
 |   Boot image      |    [Download](http://snapshots.linaro.org/96boards/hikey/linaro/debian/latest/boot-linaro-stretch-developer-hikey-*.img.gz)      |
 |:------------------|:-----------------------|

--- a/consumer/hikey/hikey960/installation/board-recovery.md
+++ b/consumer/hikey/hikey960/installation/board-recovery.md
@@ -22,7 +22,7 @@ to reinstall the primary bootloader.
 ### Download the bootloader binaries
 
 The bootloader binaries for HiKey960 can be downloaded
-[here](http://snapshots.linaro.org/96boards/reference-platform/components/uefi-staging/latest/hikey960/release/).
+[here](http://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/hikey960/release/).
 
 ### Make sure fastboot is set up on host computer
 


### PR DESCRIPTION
Latest UEFI binaries were moved to `https://snapshots.linaro.org/reference-platform/components/uefi-staging/latest/`. Hence fix those in docs and also fix couple of references to `builds.96boards.org`.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>