### PR TITLE
db410c: update qdl instructions

### DIFF
--- a/consumer/dragonboard/dragonboard410c/installation/board-recovery.md
+++ b/consumer/dragonboard/dragonboard410c/installation/board-recovery.md
@@ -47,7 +47,7 @@ http://snapshots.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragon
 Then run:
 
     cd dragonboard-410c-bootloader-emmc-linux-*/
-    sudo <PATH to qdl>/qdl prog_emmc_firehose_8916.mbn rawprogram.xml patch.xml
+    sudo <PATH to qdl>/qdl prog_emmc_firehose_8916.mbn rawprogram*.xml patch*.xml
 
 It should take a few seconds. And you should eventually get something like below
 from QDL stdout:


### PR DESCRIPTION
Some bootloader packages have rawprogram.xml and patch.xml, some have rawprogram0.xml and patch0.xml. With this change the instructions would work in both cases.