### PR TITLE
Moving the DragonBoard410c contribute guide to the generic DragonBoard guides folder

### DIFF
--- a/consumer/dragonboard/dragonboard410c/README.md
+++ b/consumer/dragonboard/dragonboard410c/README.md
@@ -33,5 +33,5 @@ A comprehensive guide to using the [DragonBoard 410c](https://www.96boards.org/p
    - Explore what makes your DragonBoard 410c unique, technical specifications, schematics, hardware notes and more...
 - [Troubleshooting and Support](support/)
    - From bug reports and current issues, to forum access and other useful resources, we want to help you find answers
-- [Contribute](downloads/contribute.md)
+- [Contribute](../guides/contribute/)
    - How to contribute patches into the Dragonboard 410c software releases

--- a/consumer/dragonboard/guides/contribute/README.md
+++ b/consumer/dragonboard/guides/contribute/README.md
@@ -1,10 +1,8 @@
 ---
 title: Contributing to Linaro releases for DragonBoard-410c
-permalink: /documentation/consumer/dragonboard/dragonboard410c/downloads/contribute.md.html
-redirect_from:
-- /db410c-getting-started/Downloads/Contribute.md/
--  /documentation/ConsumerEdition/DragonBoard-410c/Downloads/Contribute.md.html
-- /documentation/consumer/dragonboard410c/downloads/contribute.md.html
+permalink: /documentation/consumer/dragonboard/guides/contribute/
+description: >
+    This page provides instructions for developers willing to contribute to the Linaro releases for Dragonboard 410c. This is applicable to the following components...
 ---
 # Contributing to Linaro releases for Dragonboard 410c
 


### PR DESCRIPTION
Moving the DragonBoard410c contribute guide to the generic DragonBoard guides folder
- redirects added using the jekyll_redirect_from plugin have been moved to the routingrules.json file in the [website repo](https://github.com/96boards/website)
- the new structure used - folder containing a `README.md` file to avoid using .md.html permalinks