### PR TITLE
mezzanine: on-camera: Remove Useful Guides

### DIFF
--- a/mezzanine/on-camera/README.md
+++ b/mezzanine/on-camera/README.md
@@ -32,5 +32,4 @@ permalink: /documentation/mezzanine/on-camera/
 
 ### 2.1) Guides
 
-- [Useful Guides](guides/)
 - [Quick Start](files/on-camera-quick-start.pdf)

--- a/mezzanine/on-camera/guides/README.md
+++ b/mezzanine/on-camera/guides/README.md
@@ -1,8 +1,0 @@
----
-title: On Camera Mezzanine Guides
-permalink: /documentation/mezzanine/on-camera/guides/
----
-
-# On Camera Mezzanine Guides
-
-Coming Soon...


### PR DESCRIPTION
The guides for the on-camera mezzanine are not "Coming Soon". There
are no confirmed plans to write any guides for this board so remove
the misleading placeholder.

Fixes: #803
Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>