### PR TITLE
Update getting started for Ultra96v2

### DIFF
--- a/consumer/avenger96/support/README.md
+++ b/consumer/avenger96/support/README.md
@@ -6,7 +6,7 @@ permalink: /documentation/consumer/avenger96/support/
 
 Please take advantage of the many Avenger96 resources available to you through STMicro, 96Boards and Arrow.
 
-- [DragonBoard 845c Forum](https://discuss.96boards.org/c/products/avenger96)
+- [Avenger96 Forum](https://discuss.96boards.org/c/products/avenger96)
    - The Avenger96 has its very own 96Boards forum. If you can't find a pre-existing thread that addresses your issue, start your own and let the community help out!
 - [Report a bug!](../../../Extras/Report_a_bug.md)
    - Instructions on how to report bugs for any of our 96Boards hardware and software, this includes the Avenger96!

--- a/consumer/ultra96/ultra96-v2/getting-started/README.md
+++ b/consumer/ultra96/ultra96-v2/getting-started/README.md
@@ -33,8 +33,7 @@ Learn about your Ultra96 board as well as how to prepare and set up for basic us
 
 # Out of the Box
 
-The following subsections describe how to get started with the Ultra96 using the release build shipped with your board. 
-The MicroSD card provided in the kit is blank. Download the [MicroSD card image](http://avnet.me/ultra96-v2-oob). 
+The following subsections describe how to get started with the Ultra96 using the release build shipped with your board. The MicroSD card provided in the kit is blank. Download the [MicroSD card image](http://avnet.me/ultra96-v2-oob). An easy way to copy the linux image to the MicroSD card uses [Etcher](https://www.balena.io/etcher/).
 
 <img src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v2/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v2/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" width="250" height="160" />
 <img src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v2/additional-docs/images/images-board/sd/ultra96-back-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v2/additional-docs/images/images-board/sd/ultra96-back-sd.png?raw=true" width="250" height="160" />
@@ -59,26 +58,28 @@ The MicroSD card provided in the kit is blank. Download the [MicroSD card image]
 
 ## Starting the board for the first time
 
-The Ultra96 comes preloaded with Linux and can be up and running in two ways:
+The Ultra96 comes with a blank MicroSD card that must be loaded with linux before it can be used. Download the [MicroSD card image](http://avnet.me/ultra96-v2-oob). An easy way to copy the linux image to the MicroSD card uses [Etcher](https://www.balena.io/etcher/).
+
+After loading the linux image on the card, it can be up and running in two ways:
 
 > NOTE: In both cases ensure the included microSD card is fully inserted in the microSD card cage.
 
 - **Option 1**
-   - Connect the power supply to the Ultra96.
-   - Momentarily press the button labeled SW3 / POWER.  It is located next to the power supply jack.
-   - The first sign that the boot process has begun will be an LED labeled DS6 / DONE illuminating.  This means that the bistream for the FPGA portion of Ultra96 has successfully loaded.  This happens during uboot.
-   - Once LED2 begins to show a regular "heartbeat" Linux is up and running.
+   - Connect the power supply to the Ultra96, the green LED D17 will illuminate.
+   - Momentarily press the button labeled SW4 / POWER.  It is located between the two USB 3.0 Type A ports, the green power on LED D2 will illuminate.
+   - The first sign that the boot process has begun will be an blue LED labeled D1 / DONE illuminating.  This means that the bistream for the FPGA portion of Ultra96v2 has successfully loaded.  This happens during uboot.
+   - Once LED D7 begins to show a regular "heartbeat" Linux is up and running.
    - From a laptop or other device search for and connect to the WI-FI network called Ultra96_xxxxxxxxxxxx, where the 12 x's correspond to Ultra96's MAC ID.
    - From a browser, go to http://192.168.2.1
-   - You will be greeted by Ultra96's homepage.
+   - You will be greeted by Ultra96v2's homepage.
 
 - **Option 2**
-   - Connect the Ultra96 to a DisplayPort monitor with a miniDP to DisplayPort cable plugged into the connector labeled DISPLAY PORT.
+   - Connect the Ultra96v2 to a DisplayPort monitor with a miniDP to DisplayPort cable plugged into the connector labeled DISPLAY PORT.
    - Connect a USB keyboard and mouse to J8 and J9, or through a USB hub connected to J8 or J9.
    - Connect the power supply to the Ultra96.
-   - Momentarily press the button labeled SW3 / POWER.  It is located next to the power supply jack.
+   - Momentarily press the button labeled SW4 / POWER.  It is located between the two USB 3.0 Type A ports.
    - You will be able to watch the progress of the boot process on the monitor.
-   - As in Option 1, an LED labeled DS6 / DONE will illuminate at some point during boot.  This means that the bistream for the FPGA portion of Ultra96 has successfully loaded.
+   - As in Option 1, an LED labeled D1 / DONE will illuminate at some point during boot.  This means that the bistream for the FPGA portion of Ultra96 has successfully loaded.
    - Linux will boot, launching a desktop environment.
 
 ***

--- a/consumer/ultra96/ultra96-v2/getting-started/README.md
+++ b/consumer/ultra96/ultra96-v2/getting-started/README.md
@@ -33,7 +33,8 @@ Learn about your Ultra96 board as well as how to prepare and set up for basic us
 
 # Out of the Box
 
-The following subsections describe how to get started with the Ultra96 using the release build shipped with your board. The Ultra96 is ready to use “out of the box” and comes with a pre-flashed microSD card which boots Linux. 
+The following subsections describe how to get started with the Ultra96 using the release build shipped with your board. 
+The MicroSD card provided in the kit is blank. Download the [MicroSD card image](http://avnet.me/ultra96-v2-oob). 
 
 <img src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v2/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v2/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" width="250" height="160" />
 <img src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v2/additional-docs/images/images-board/sd/ultra96-back-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v2/additional-docs/images/images-board/sd/ultra96-back-sd.png?raw=true" width="250" height="160" />

--- a/som/tb-96aiot/getting-started/README.md
+++ b/som/tb-96aiot/getting-started/README.md
@@ -53,23 +53,103 @@ The following subsections should describe how to get started with the TB-96AIoT 
 
 <img src="../additional-docs/images/images-wiki/som-insert.png" data-canonical-src="" width="300" height="300" />
 
-- Insert the TB-96AIoT SoM in the 96Boards Carrier Board as Shown in the figure above, making sure that connectors X1 and X2 are bing utilised.
-- Configure the MUX Switches on the Carrier Board as follows
-	- The switches for TB-96AIoT are configured as follows
-	- All switch on S1,S2,S6,S7 ,S10,S11,S12,S14,S15, config to disconnect.
-	- All switch on S8,S9 config to connect for TFcard
-	- Bit2 & Bit3 on S16 config to connect.
-	- Bit1 & Bbit2 on S5 config to connect fot debug uart
-	- Bit4 on S3 config to connect for debug uart
-	- Bit1 & Bit2 on S13 config to connect for USB
-- Connect the TYPEC to PC
-- Long press and hold the Maskrom button as shown in the following figure.
-- Insert power supply.
-- Continue to the [Installation page](../installation/).
+### Step 1
+
+Insert the TB-96AIoT SoM in the 96Boards Carrier Board as Shown in the figure above, making sure that connectors X1 and X2 are bing utilised.
+
+### Step 2
+
+Configure the MUX Switches on the Carrier Board as follows:
+
+**NPU or CPU UART Debug ports selection**: voltage Level shifter enable S3/Bit4 and S5.
+For TB-96AIOT RK1808 SOM UART Debug: Bit4 on S3, S5
+S3 Bits functions:
+
+- Bit1:Not used
+- Bit2: Not used
+- Bit3: Not used
+- Bit4: UART voltage
+- Only one UART debug port, Bit4 on S3 is ON with 3V3, Bit1/Bit2 of S5 are ON and Bit3/Bit4 of S5 are OFF
+
+**TF Card switches:S6/S7/S8/S9**
+For TB-96AIOT RK1808 SOM
+
+- S6,S7,S10 are OFF and S8,S9 must be ON for TF Card.
+
+**High speed expansion SDIO  port: S11/S12 switches**
+
+For TB-96AIOT RK1808 SOM
+
+- All Bits of S11 and S12 are ON, and all Bits of S8,S9,S1,S2 are OFF. 
+- During this case, the TF Card is forbidden to use.
+
+**JTAG switches: S10**
+
+For TB-96AIOT RK1808 SOM JTAG
+
+- Bit3,Bit4 of S10 are ON. All the switches on S8,S9 must be ON and all the switches of S6,S7,S1,S2,S11,S12 must be OFF.
+- JTAG and TF card can not work at the same time.
+
+**96Boards HS Speed ** **USB2.0:  S13**
+
+For TB-96AIOT RK1808 SOM
+
+- The USB2.0 of HS speed USB2.0 and MiniPCIe are muxed.
+- The Bit1,Bit2,Bit4 of S13 must be ON. If MiniPCIE LTE Module is used, the Bit3 of S13 must be ON. If USB2.0 on High speed expansion connector is required,Bit3 of S13 must be OFF.
+
+**Display port switches: S14**
+
+For TB-96AIOT RK1808 SOM(only 1 MIPI DSI supported)
+
+- If the MIPI DSI display port on RK LCD connector(J5001) is used, the Bit2 of S14 must be OFF.
+- If the MIPI display port on High speed expansion connector is used, the Bit2/Bit3 of S14 must be ON.
+
+Notes: the DSI and eDP display of RK LCD connector(J5001) are the same.
+
+The eDP display can be purchased by: [https://item.taobao.com/item.htm?ft=t&id=596997529966](https://item.taobao.com/item.htm?ft=t&id=596997529966)(eDP display) or contact with [sales@beiqicloud.com](mailto:sales@beiqicloud.com) 
+
+The DSI display can be purchased by:
+
+[https://item.taobao.com/item.htm?ft=t&id=596790859176](https://item.taobao.com/item.htm?ft=t&id=596790859176) Or [https://www.aliexpress.com/item/4000096367335.html](https://www.aliexpress.com/item/4000096367335.html)
+
+**Camera CSI switches: S15**
+
+For TB-96AIOT RK1808 SOM
+
+- The RK1808 only has a MIPI CSI interface.
+- If the Bit2 of S15 is OFF, the MIPI CSI will be connected to CAM3 camera connector(CON1702).
+- If the Bit2 of S15 is ON and the Bit3 of S15 is OFF.The MIPI CSI will be connected to high speed expansion connector(CON509).
+
+**GPIO switches: S16**
+
+For TB-96AIOT RK1808 SOM
+
+- Bit1:Void
+- Bit2:RK1808 earphone plugin check
+- Bit3:RK1808 USB port Host Power enable.
+- Bit4: Void
+- The Bit2,Bit3 must be ON.
+
+
+### Step 3
+
+Connect the TYPEC to PC
+
+### Step 4
+
+Long press and hold the Maskrom button as shown in the following figure.
+
+### Step 5
+
+Insert power supply.
+
+### Step 6
+
+Continue to the [Installation page](../installation/).
 
 ***
 
-## What's Next?
+## Next steps
 
 If you are already familiar with the TB-96AIoT board and would like to change out the stock operating system, please proceed to one of the following pages:
 
@@ -80,4 +160,4 @@ If you are already familiar with the TB-96AIoT board and would like to change ou
 
 Back to the [TB-96AIoT documentation home page](../)
 
-***   
+***


### PR DESCRIPTION
The current getting started documentation for the Ultra96v2 is not correct. I updated it for the v2 board revision (new LED arrangement) and the current distributed package (blank SD card). This should address #855  that I reported.

Note that I squashed some commits and force pushed them to my repo, but github seems to be behind as I write this. Hopefully it will catch up before you see it.