### PR TITLE
link and typo fixes

### DIFF
--- a/consumer/rock/installation/linux-mac-rkdeveloptool-android.md
+++ b/consumer/rock/installation/linux-mac-rkdeveloptool-android.md
@@ -26,7 +26,7 @@ To build rkdeveloptool on a debian based Linux distribution, follow the instruct
 
 Install build dependency:
 
-    sudo apt-get install libudev-dev libusb-1.0-0-dev dh-autoreconf
+    sudo apt-get install libudev-dev libusb-1.0-0-dev dh-autoreconf libglib2.0-dev
 
 Clone the source code and build:
 

--- a/consumer/ultra96/ultra96-v2/hardware-docs/README.md
+++ b/consumer/ultra96/ultra96-v2/hardware-docs/README.md
@@ -9,7 +9,7 @@ Explore what makes your Ultra96 unique, technical specifications, schematics, ha
 
 ## User Guides
 
-- Hardware User Manual (Beta) [View](http://www.zedboard.org/sites/default/files/documentations/Ultra96-HW-User-Guide-rev-1-0-V0_9_preliminary.pdf) (.pdf)
+- Hardware User Manual (Beta) [View](http://www.zedboard.org/sites/default/files/documentations/Ultra96-V2-HW-User-Guide-rev-1-0-V1_0_Preliminary_0.pdf) (.pdf)
 - Product Brief [View](http://zedboard.org/sites/default/files/product_briefs/5354-pb-ultra96-v3b.pdf) (.pdf)
 
 ## Hardware

--- a/enterprise/akebi96/getting-started/README.md
+++ b/enterprise/akebi96/getting-started/README.md
@@ -10,7 +10,7 @@ Learn about your Akebi96 board as well as how to prepare and set up for basic us
 
 **Need**
 - [Akebi96 Board](https://www.96boards.org/product/akebi96/)
-   - Board based on the HiSilicon Hi3798C V200 Processor
+   - Board based on the Socionext LD20 Processor
 - Power adapter
    - 96Boards specifications requires a 8V-18V with 2000mA Power adapter
 - USB Keyboard and Mouse

--- a/enterprise/akebi96/support/README.md
+++ b/enterprise/akebi96/support/README.md
@@ -4,13 +4,10 @@ permalink: /documentation/enterprise/akebi96/support/
 ---
 # Troubleshooting
 
-Please take advantage of the many Board-X resources available to you through 96Boards, Tocoding and Linaro
+Please take advantage of the many Board-X resources available to you through 96Boards and Linaro
 
-- [96Boards Akebi96 Forum](https://discuss.96boards.org/c/products/akebi96)
+- [96Boards Akebi96 Forum](https://discuss.96boards.org/)
    - The Akebi96 has its very own 96Boards forum. If you can't find a pre-existing thread that addresses your issue, start your own and let the community help out!
-- [Akebi96 on Tocoding site](http://en.tocoding.com/index.php/96boards-akebi96/)
-- [Report a bug!](../../../Extras/Report_a_bug.md)
-   - Instructions on how to report bugs for any of our 96Boards hardware and software, this includes the Board-X!
 - [Akebi96 Tools](https://github.com/96boards-akebi96/akebi96-tools)
 - [Board Recovery](https://github.com/96boards-akebi96/Documentation/)
    - Bricked board? Many software issues can be fixed with a simple "board recovery"


### PR DESCRIPTION
- akebi96: multiple links and typos fixed
- rock: add missing dependency. fixes: #873
- ultra96v2: fixed hw user manual link. fixes: #881

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>