### PR TITLE
Fix of 404 links

### DIFF
--- a/iot/orangepi-i96/downloads/README.md
+++ b/iot/orangepi-i96/downloads/README.md
@@ -16,11 +16,9 @@ If you would like to switch the Operating System on your Orange Pi i96, update t
 
 All images are hosted by Orange Pi on the [Download and Resource center](http://www.orangepi.org/downloadresources/).
 
-- [Debian](http://www.orangepi.org/downloadresources/orangepii96/orangepii96_75fdb65e681d4439f14e4531.html)
-- [Ubuntu Server](http://www.orangepi.org/downloadresources/orangepii96/orangepii96_152e742f43617425856b7ce6.html)
-- [Android Nand](http://www.orangepi.org/downloadresources/orangepii96/orangepii96_24af88648f5c0e805eeb834f.html)
-- [Android Tcard](http://www.orangepi.org/downloadresources/orangepii96/orangepii96_9dc4194002747ede4293fd97.html)
-- [Raspbian Server](http://www.orangepi.org/downloadresources/orangepii96/orangepii96_1181fa5c177169c6c546e54b.html)
+- [Debian](http://www.orangepi.org/downloadresources/orangepii96/orangepii96_94bf0378a51e1277ff416638.html)
+- [Ubuntu Server](http://www.orangepi.org/downloadresources/orangepii96/orangepii96_72069b4e8e756bcc44ae393e.html)
+- [Android](http://www.orangepi.org/downloadresources/orangepii96/orangepii96_ba031ea29764e3de7b619dea.html)
 
 Proceed to [Installation page](../installation/)
 


### PR DESCRIPTION
Updated the 404 Links for the Debian,Ubuntu.
 Added the Android Image Download Page.
 Removed Android SD Card, and Android NAND as those are Now merged into one Android Link leading to the files.
 Removed Raspbian Download as its not present on the Orange Pi Website anymore.  

Signed of by Thore Krug: opensource[at]thorekrug.de