### PR TITLE
fix broken links in documentation repo

### DIFF
--- a/consumer/dragonboard/dragonboard410c/guides/fedora.md
+++ b/consumer/dragonboard/dragonboard410c/guides/fedora.md
@@ -18,7 +18,7 @@ Fedora is a Linux distribution developed by the community-supported Fedora Proje
 - [Bootloader](https://builds.96boards.org/releases/dragonboard410c/linaro/rescue/17.09/dragonboard410c_bootloader_emmc_linux-88.zip)
 - [U-Boot](https://fedora.roving-it.com/qcom-db410c/u-boot.img)
 - [LK firmware with display output](https://fedora.roving-it.com/qcom-db410c/emmc_appsboot.mbn)
-- [Fedora Aarch64 Build](https://dl.fedoraproject.org/pub/fedora/linux/releases/29/Server/aarch64/images/Fedora-Server-29-1.2.aarch64.raw.xz)
+- [Fedora Aarch64 Build](https://dl.fedoraproject.org/pub/fedora/linux/releases/33/Server/aarch64/images/Fedora-Server-33-1.3.aarch64.raw.xz)
 
 ### Flash Bootloader
 - Extract rescue zip:

--- a/consumer/dragonboard/dragonboard410c/guides/force-display-res.md
+++ b/consumer/dragonboard/dragonboard410c/guides/force-display-res.md
@@ -25,7 +25,7 @@ This is a Linux kernel feature that can be used:
     feature is provided as a workaround for broken hardware, it is
     disabled by default.
 
-Details and instructions how to build your own EDID data are given in [Documentation/EDID/HOWTO.txt](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/EDID/HOWTO.txt).
+Details and instructions how to build your own EDID data are given in [Documentation/EDID/HOWTO.txt](https://www.kernel.org/doc/Documentation/EDID/HOWTO.txt).
 
 So basically, when using this feature the real EDID is not used, and is being replaced by a fake one.
 

--- a/consumer/dragonboard/dragonboard820c/installation/linux-fastboot.md
+++ b/consumer/dragonboard/dragonboard820c/installation/linux-fastboot.md
@@ -80,4 +80,4 @@ If all steps went fine and you have flashed `ALIP` image, you should now have a 
 
 Initial support for DragonBoard 820c has been added into the OpenEmbedded QCOM BSP later, including the appropriate kernel recipe. To build an image for Dragonboard 820c , simply follow the same instructions as usual, from [Dragonboard-410c-OpenEmbedded-and-Yocto](https://github.com/Linaro/documentation/blob/master/Reference-Platform/CECommon/OE.md). When you select the MACHINE to build for, pick `dragonboard-820c`.
 
-The board has been added to the Linaro Reference Platform OpenEmbedded builds, and prebuilt images for this board are available here: [http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/rocko/latest/).
+The board has been added to the Linaro Reference Platform OpenEmbedded builds, and prebuilt images for this board are available here: [http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/dunfell/192/](http://snapshots.linaro.org/96boards/dragonboard820c/linaro/openembedded/dunfell/192/).

--- a/consumer/dragonboard/dragonboard845c/downloads/debian.md
+++ b/consumer/dragonboard/dragonboard845c/downloads/debian.md
@@ -17,12 +17,12 @@ permalink: /documentation/consumer/dragonboard/dragonboard845c/downloads/debian.
 
 | Boot image                                                                                                                             |
 |:---------------------------------------------------------------------------------------------------------------------------------------|
-| [Download](http://releases.linaro.org/96boards/dragonboard845c/linaro/debian/latest/boot-linaro-buster-dragonboard-845c-*.img.gz)      |
+| [Download](http://releases.linaro.org/96boards/dragonboard845c/linaro/debian/latest/boot-linaro-sid-dragonboard-845c-*.img.gz)      |
 | [Release Notes](http://releases.linaro.org/96boards/dragonboard845c/linaro/debian/latest/)                                             |
 
 | Rootfs image                                                                                                                           |
 |:---------------------------------------------------------------------------------------------------------------------------------------|
-| [Desktop](http://releases.linaro.org/96boards/dragonboard845c/linaro/debian/latest/linaro-*-alip-dragonboard-845c-*.img.gz)       |
+| [Desktop](http://releases.linaro.org/96boards/dragonboard845c/linaro/debian/latest/linaro-*-gnome-dragonboard-845c-*.img.gz)       |
 | [Developer](http://releases.linaro.org/96boards/dragonboard845c/linaro/debian/latest/linaro-*-developer-dragonboard-845c-*.img.gz)|
 | [Release Notes](http://releases.linaro.org/96boards/dragonboard845c/linaro/debian/latest/)                                             |
 

--- a/consumer/dragonboard/dragonboard845c/downloads/open-embedded.md
+++ b/consumer/dragonboard/dragonboard845c/downloads/open-embedded.md
@@ -26,7 +26,7 @@ Choose between RPB and RPB-Wayland. You will need to download the "boot image" a
 | RPB-Wayland                                                                                                                             |
 |:----------------------------------------------------------------------------------------------------------------------------------------|
 | [Boot Image](http://releases.linaro.org/96boards/dragonboard845c/linaro/openembedded/latest/rpb-wayland/boot--*-r0-dragonboard-845c-*.img)                                                                                                               |
-| [Desktop](http://releases.linaro.org/96boards/dragonboard845c/linaro/openembedded/latest/rpb-wayland/rpb-desktop-image-dragonboard-845c-*.rootfs.ext4.gz) or [Console](http://releases.linaro.org/96boards/dragonboard845c/linaro/openembedded/latest/rpb-wayland/rpb-console-image-dragonboard-845c-*.rootfs.ext4.gz)                                                       |
+| [Desktop](http://releases.linaro.org/96boards/dragonboard845c/linaro/openembedded/latest/rpb-wayland/rpb-weston-image-test-dragonboard-845c-*.rootfs.ext4.gz) or [Console](http://releases.linaro.org/96boards/dragonboard845c/linaro/openembedded/latest/rpb-wayland/rpb-console-image-dragonboard-845c-*.rootfs.ext4.gz)                                                       |
 | [Build Folder](http://releases.linaro.org/96boards/dragonboard845c/linaro/openembedded/latest/rpb/)                 |
 
 > NOTE: Only download one root file system (Console or Desktop). You should match the type of rootfs to the boot image you downloaded above.

--- a/consumer/hikey/hikey620/downloads/aosp.md
+++ b/consumer/hikey/hikey620/downloads/aosp.md
@@ -24,19 +24,19 @@ redirect_from:
 
 ## Fastboot files
 
-|   Bootloader      |   [Build Folder](https://snapshots.linaro.org/96boards/hikey/linaro/uefi-openplatformpkg/latest/)    |
+|   Bootloader      |   [Build Folder](https://releases.linaro.org/96boards/hikey/linaro/binaries/latest/pkg/latest/)    |
 |:------------------|:---------------------------------------------------------------------------------------------------------|
-| l-loader.bin      | [Download](https://snapshots.linaro.org/96boards/hikey/linaro/uefi-openplatformpkg/latest/l-loader.bin)                |
-| fip.bin           | [Download](https://snapshots.linaro.org/96boards/hikey/linaro/uefi-openplatformpkg/latest/fip.bin)                     |
-| nvme.img          | [Download](https://snapshots.linaro.org/96boards/hikey/linaro/uefi-openplatformpkg/latest/nvme.img)                    |
-| ptable-aosp.img   | [4GB](https://snapshots.linaro.org/96boards/hikey/linaro/uefi-openplatformpkg/latest/ptable-aosp-4g.img) / [8GB](https://snapshots.linaro.org/96boards/hikey/linaro/uefi-openplatformpkg/latest/ptable-aosp-8g.img)                                     |
+| l-loader.bin      | [Download](https://releases.linaro.org/96boards/hikey/linaro/binaries/latest/pkg/latest/l-loader.bin)                |
+| fip.bin           | [Download](https://releases.linaro.org/96boards/hikey/linaro/binaries/latest/pkg/latest/fip.bin)                     |
+| nvme.img          | [Download](https://releases.linaro.org/96boards/hikey/linaro/binaries/latest/pkg/latest/nvme.img)                    |
+| ptable-aosp.img   | [4GB](https://releases.linaro.org/96boards/hikey/linaro/binaries/latest/pkg/latest/ptable-aosp-4g.img) / [8GB](https://releases.linaro.org/96boards/hikey/linaro/binaries/latest/pkg/latest/ptable-aosp-8g.img)                                     |
 | hisi-idt.py       | [Download]()http://builds.96boards.org/releases/reference-platform/debian/hikey/16.06/bootloader/hisi-idt.py                 |
 
 
-| Latest build files        | [Build Folder](http://snapshots.linaro.org/android/lkft/lkft-aosp-master/latest/)                 |
+| Latest build files        | [Build Folder](http://snapshots.linaro.org/android/lkft/lkft-hikey-aosp-master-5.4/latest/)                 |
 | :------------------------ | :--------------------------------------------------------------------------------------------------   |
-| boot_fat.uefi.img.tar.xz  | [Download](http://snapshots.linaro.org/android/lkft/lkft-aosp-master/latest/boot.img.xz) |
-| system.img.tar.xz         | [Download](http://snapshots.linaro.org/android/lkft/lkft-aosp-master/latest/system.img.xz)        |
-| userdata.img.tar.xz       | [Download](http://snapshots.linaro.org/android/lkft/lkft-aosp-master/latest/userdata.img.xz)      |
+| boot_fat.uefi.img.tar.xz  | [Download](http://snapshots.linaro.org/android/lkft/lkft-hikey-aosp-master-5.4/latest/*-boot.img.xz) |
+| system.img.tar.xz         | [Download](http://snapshots.linaro.org/android/lkft/lkft-hikey-aosp-master-5.4/latest/*-system.img.xz)        |
+| userdata.img.tar.xz       | [Download](http://snapshots.linaro.org/android/lkft/lkft-hikey-aosp-master-5.4/latest/*-userdata.img.xz)      |
 
 ### Continue to [Installation page](../installation/)

--- a/consumer/sophon-edge/guides/sd_boot_guide.md
+++ b/consumer/sophon-edge/guides/sd_boot_guide.md
@@ -44,7 +44,7 @@ Now that minicom has been configured it’s time to get the relevant files for f
 
 `$ git clone https://github.com/BM1880-BIRD/bm1880-system-sdk.git`
 
-Next it's important to configure the cross comilpation toolchain for the rootfs. [Download the toolchian here](https://sophon-file.bitmain.com.cn/sophon-prod/drive/18/11/08/11/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu.tar.xz.zip), and unzip it into the bm1880-system-sdk directory.
+Next it's important to configure the cross comilpation toolchain for the rootfs. [Download the toolchian here](https://releases.linaro.org/components/toolchain/binaries/6.3-2017.05/aarch64-linux-gnu/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu.tar.xz), and unzip it into the bm1880-system-sdk directory.
 
 Navigate to the bm1880-system-sdk directory and configure envsetup_edb.sh to point to the downloaded toolchain.
 

--- a/consumer/ultra96/ultra96-v1/hardware-docs/README.md
+++ b/consumer/ultra96/ultra96-v1/hardware-docs/README.md
@@ -9,7 +9,7 @@ Explore what makes your Ultra96 unique, technical specifications, schematics, ha
 
 ## User Guides
 
-- Hardware User Manual (Beta) [View](http://www.zedboard.org/sites/default/files/documentations/Ultra96-HW-User-Guide-rev-1-0-V0_9_preliminary.pdf) (.pdf)
+- Hardware User Manual (Beta) [View](http://zedboard.org/sites/default/files/documentations/Ultra96-HW-User-Guide-rev-1-0-V1_1.pdf) (.pdf)
 - Product Brief [View](http://zedboard.org/sites/default/files/product_briefs/5354-pb-ultra96-v3b.pdf) (.pdf)
 
 ## Hardware
@@ -17,7 +17,6 @@ Explore what makes your Ultra96 unique, technical specifications, schematics, ha
 - Schematics [View](/documentation/consumer/ultra96/ultra96-v1/hardware-docs/files/ultra96-schematics.pdf) (.pdf)
 - Assembly [View](http://www.zedboard.org/sites/default/files/documentations/AES-ULTRA96-G%20assembly%20180315.pdf) (.pdf)
 - Bill of Materials [View](http://www.zedboard.org/sites/default/files/documentations/AES-ULTRA96-G%20BOM%20REV%201%20180315.pdf) (.pdf)
-- Layout [View](http://www.zedboard.org/sites/default/files/documentations/AES-ULTRA96-G%20layout%20180315.pdf) (.pdf)
 - Mechanical and Drill [View](http://www.zedboard.org/sites/default/files/documentations/AES-ULTRA96-G%20Mechanical%20and%20Drill%20180315.pdf) (.pdf)
 - Power Analysis [View](http://www.zedboard.org/sites/default/files/documentations/Ultra96_XPE_2016_4.zip) (.pdf)
 - Net Length [View](http://www.zedboard.org/sites/default/files/documentations/AES-ULTRA96-G%20net%20length%20180315.txt) (.pdf)

--- a/consumer/ultra96/ultra96-v1/hardware-docs/hw-user-manual.md
+++ b/consumer/ultra96/ultra96-v1/hardware-docs/hw-user-manual.md
@@ -4,7 +4,7 @@ title: Ultra96 Development Board User Manual
 ---
 This page is currently under construction...
 
-- [Get access to Hardware User Manual](http://www.zedboard.org/sites/default/files/documentations/Ultra96-HW-User-Guide-rev-1-0-V0_9_preliminary.pdf)
+- [Get access to Hardware User Manual](http://zedboard.org/sites/default/files/documentations/Ultra96-HW-User-Guide-rev-1-0-V1_1.pdf)
 
 <img src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v1/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v1/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" width="250" height="160" />
 <img src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v1/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v1/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" width="250" height="160" />

--- a/consumer/ultra96/ultra96-v2/hardware-docs/README.md
+++ b/consumer/ultra96/ultra96-v2/hardware-docs/README.md
@@ -9,7 +9,7 @@ Explore what makes your Ultra96 unique, technical specifications, schematics, ha
 
 ## User Guides
 
-- Hardware User Manual (Beta) [View](http://www.zedboard.org/sites/default/files/documentations/Ultra96-HW-User-Guide-rev-1-0-V1_1.pdf) (.pdf)
+- Hardware User Manual (Beta) [View](http://zedboard.org/sites/default/files/documentations/Ultra96-HW-User-Guide-rev-1-0-V1_1.pdf) (.pdf)
 - Product Brief [View](http://zedboard.org/sites/default/files/product_briefs/5354-pb-ultra96-v3b.pdf) (.pdf)
 
 ## Hardware

--- a/consumer/ultra96/ultra96-v2/hardware-docs/hw-user-manual.md
+++ b/consumer/ultra96/ultra96-v2/hardware-docs/hw-user-manual.md
@@ -4,7 +4,7 @@ title: Ultra96-V2 Development Board User Manual
 ---
 This page is currently under construction...
 
-- [Get access to Hardware User Manual](http://www.zedboard.org/sites/default/files/documentations/Ultra96-HW-User-Guide-rev-1-0-V0_9_preliminary.pdf)
+- [Get access to Hardware User Manual](http://zedboard.org/sites/default/files/documentations/Ultra96-HW-User-Guide-rev-1-0-V1_1.pdf)
 
 <img src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v2/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v2/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" width="250" height="160" />
 <img src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v2/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" data-canonical-src="https://github.com/96boards/documentation/blob/master/consumer/ultra96/ultra96-v2/additional-docs/images/images-board/sd/ultra96-front-sd.png?raw=true" width="250" height="160" />

--- a/enterprise/cello/quickstart/README.md
+++ b/enterprise/cello/quickstart/README.md
@@ -23,7 +23,6 @@ Learn about your DragonBoard™ 410c board as well as how to prepare and set up 
    - FTDI TTL-232R-3V3 (for SCP UART)
    - Micro-USB cable for console
    - 4pin Molex to 15-pin SATA power cable such as
-      - Single: [Purex PXC-M1S](http://www.microcenter.com/product/403823/4-pin_Molex_(Male)_to_15-pin_SATA_Power_Cable_6)
       - Double: [KingWin SAC-12](http://www.microcenter.com/product/409249/8_Molex_4-Pin_Male_to_Dual_15-Pin_SATA_Power_Cable)
    - SATA-eSATA adapter cable (e.g.[StarTech SATA2ESATA6](https://www.startech.com/Cables/Drive/eSATA/6foot-Shielded-eSATA-to-SATA-Cable~SATA2ESATA6))
    - SATA-SATA cable (e.g. [Delux Infinity DLX-S18](http://www.microcenter.com/product/388739/18_SATA_III_Cable))

--- a/enterprise/developerbox/getting-started/README.md
+++ b/enterprise/developerbox/getting-started/README.md
@@ -51,8 +51,8 @@ If you have a preferred OS now is the time to find out if it is
 available in the [Downloads and Installation](../installation/) section. This section will provide links to various Linaro supported or third party ISO images, as well as detailed installation instructions.
 
 Alternatively; if you have a simple home network (or a very relaxed corporate one) then
-it is possible to install the [Enterprise Reference
-Platform](https://platforms.linaro.org/documentation/Reference-Platform/Platforms/Enterprise/), with a fully operational desktop environment,
+it is possible to install the Enterprise Reference
+Platform, with a fully operational desktop environment,
 directly from within the EDK2 menu system. The Enterprise Reference
 Platform is intended to be used as a reference for component validation
 and, among other things, pairs Debian Stretch with a more recent kernel

--- a/iot/orangepi-i96/build/README.md
+++ b/iot/orangepi-i96/build/README.md
@@ -13,5 +13,5 @@ Learn how to setup and build for the Orange Pi i96.
 ## Third Party Build instructions
 
 - [Build System - All components](https://github.com/orangepi-xunlong/OrangePi_Build)
-- [Android Source Code (Download)](http://www.orangepi.org/downloadresources/orangepii96/orangepizeroplus2H5_3a42f5016c804d4a.html)
+- [Android Source Code (Download)](http://www.orangepi.org/downloadresources/orangepii96/orangepii96_96c513a892ee63fe78d03018.html)
 - [Linux Source Code (Download)](https://github.com/orangepi-xunlong)

--- a/iot/orangepi-i96/getting-started/README.md
+++ b/iot/orangepi-i96/getting-started/README.md
@@ -50,7 +50,7 @@ The following subsections should describe how to get started with the Orange Pi 
 |  OS Support          | Android, Ubuntu, Debian, etc.                                                                    |
 |  Size                | 60mm × 30mm                                                                                      |
 
-For more information and instructions on how to get started with the Orange Pi i96, please take a look at the [Hardware User Manual](http://www.orangepi.org/downloadresources/orangepii96/orangepizeroplus2H5_9407e427561c7a20.html)
+For more information and instructions on how to get started with the Orange Pi i96, please take a look at the [Hardware User Manual](http://www.orangepi.org/downloadresources/orangepii96/orangepii96_892f5d5eb9dd5c0e09cc8f70.html)
 
 ***
 

--- a/iot/wistrio/downloads/README.md
+++ b/iot/wistrio/downloads/README.md
@@ -12,7 +12,7 @@ permalink: /documentation/iot/wistrio/downloads/
 > Note: only windows based setup has been tested. Linux support is unknown
 
 - [GCC arm Cross-Compiler for Windows](https://developer.arm.com/-/media/Files/downloads/gnu-rm/5_4-2016q3/gcc-arm-none-eabi-5_4-2016q3-20160926-win32.exe?revision=b4aea310-4072-4388-8567-fc9cd4aded8b?product=GNU%20Arm%20Embedded%20Toolchain,32-bit,,Windows,5-2016-q3-update)
-- [CP210x Windows Driver](http://docs.rakwireless.com/en/LoRa/WisTrio-LoRa-RAK5205/Tools/CP210x_Windows_Drivers.zip)
+- [CP210x Windows Driver](https://www.silabs.com/documents/public/software/CP210x_Windows_Drivers.zip)
 - [STM32 Flasher](https://www.st.com/en/development-tools/flasher-stm32.html)
 - [ARM Kiel MDK-Arm](https://www.keil.com/download/product/)
 - [Sample Project](https://github.com/RAKWireless/RAK5205-WisTrio-LoRa)

--- a/mezzanine/stm32/README.md
+++ b/mezzanine/stm32/README.md
@@ -45,4 +45,3 @@ The [96Boards STM32 Sensor Mezzanine](https://www.96boards.org/product/stm32/) b
 # 2) Guides and Documentation
   - [Useful Guides](guides/)
   - [Hardware Docs](files/)
-  - [Schematics Pack](http://www.st.com/resource/en/schematic_pack/b-f446e-96b01a_sch.zip)


### PR DESCRIPTION
TODO:
- https://snapshots.linaro.org/96boards/hikey960/linaro/aosp-master/latest/ :
	- needs fix on the file server side as latest folder is missing and that should not be the case

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>