### PR TITLE
Change fastboot flash command

### DIFF
--- a/consumer/dragonboard/dragonboard410c/installation/linux-fastboot.md
+++ b/consumer/dragonboard/dragonboard410c/installation/linux-fastboot.md
@@ -163,7 +163,7 @@ de82318	fastboot
 $ cd <extraction directory>
 
 # Make sure you have properly unzipped the boot and rootfs downloads
-$ sudo fastboot flash boot boot-linaro-jessie-qcom-snapdragon-arm64-**BUILD#**.img
+$ sudo fastboot flash:raw boot boot-linaro-jessie-qcom-snapdragon-arm64-**BUILD#**.img
 $ sudo fastboot flash rootfs linaro-jessie-developer-qcom-snapdragon-arm64-**BUILD#**.img
 ```
 **Note**: Replace **BUILD#** in the above commands with the file-specific date/build stamp.


### PR DESCRIPTION
I followed this guide and it worked but I had to slightly change this 1 command or else there was this error:

```
$ sudo fastboot flash boot boot-linaro-sid-dragonboard-410c-933.img
fastboot: error: Couldn't parse partition size '0x'.
$
```