### PR TITLE
consumer: db845c: fix typos

### DIFF
--- a/consumer/dragonboard/dragonboard845c/downloads/debian.md
+++ b/consumer/dragonboard/dragonboard845c/downloads/debian.md
@@ -1,5 +1,5 @@
 ---
-title: Debian Downloads for DragonBoard-410c
+title: Debian Downloads for DragonBoard-845c
 permalink: /documentation/consumer/dragonboard/dragonboard845c/downloads/debian.md.html
 ---
 # Debian

--- a/consumer/dragonboard/dragonboard845c/downloads/open-embedded.md
+++ b/consumer/dragonboard/dragonboard845c/downloads/open-embedded.md
@@ -1,5 +1,5 @@
 ---
-title: OpenEmbedded Downloads for DragonBoard-410c
+title: OpenEmbedded Downloads for DragonBoard-845c
 permalink: /documentation/consumer/dragonboard/dragonboard845c/downloads/open-embedded.md.html
 ---
 # OpenEmbedded


### PR DESCRIPTION
Wrong name was used in download pages for OE and Debian.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>