### PR TITLE
rb5: fix link to latest bootloader release

### DIFF
--- a/consumer/dragonboard/qualcomm-robotics-rb5/downloads/debian.md
+++ b/consumer/dragonboard/qualcomm-robotics-rb5/downloads/debian.md
@@ -14,8 +14,8 @@ permalink: /documentation/consumer/dragonboard/qualcomm-robotics-rb5/downloads/d
 
 | Bootloader                                                                                                                             |
 |:---------------------------------------------------------------------------------------------------------------------------------------|
-| [Download](http://releases.linaro.org/96boards/rb5/linaro/rescue/21.04/rb5-bootloader-ufs-linux-*.zip)                                 |
-| [Release Notes](http://releases.linaro.org/96boards/rb5/linaro/rescue/21.04/)                                                          |
+| [Download](http://releases.linaro.org/96boards/rb5/linaro/rescue/latest/rb5-bootloader-ufs-linux-*.zip)                                 |
+| [Release Notes](http://releases.linaro.org/96boards/rb5/linaro/rescue/latest/)                                                          |
 
 | Boot image                                                                                                                             |
 |:---------------------------------------------------------------------------------------------------------------------------------------|

--- a/consumer/dragonboard/qualcomm-robotics-rb5/downloads/debian.md
+++ b/consumer/dragonboard/qualcomm-robotics-rb5/downloads/debian.md
@@ -19,13 +19,13 @@ permalink: /documentation/consumer/dragonboard/qualcomm-robotics-rb5/downloads/d
 
 | Boot image                                                                                                                             |
 |:---------------------------------------------------------------------------------------------------------------------------------------|
-| [Download](http://snapshots.linaro.org/96boards/qrb5165-rb5/linaro/debian/latest/boot-linaro-sid-qrb5165-rb5-*.img.gz)                 |
-| [Release Notes](http://snapshots.linaro.org/96boards/qrb5165-rb5/linaro/debian/latest/)                                                |
+| [Download](http://releases.linaro.org/96boards/rb5/linaro/debian/latest/boot-linaro-sid-qrb5165-rb5-*.img.gz)                 |
+| [Release Notes](http://releases.linaro.org/96boards/rb5/linaro/debian/latest/)                                                |
 
 | Rootfs image                                                                                                                           |
 |:---------------------------------------------------------------------------------------------------------------------------------------|
-| [Desktop](http://snapshots.linaro.org/96boards/qrb5165-rb5/linaro/debian/latest/linaro-sid-gnome-qrb5165-rb5-*.img.gz)                      |
-| [Developer](http://snapshots.linaro.org/96boards/qrb5165-rb5/linaro/debian/latest/linaro-sid-developer-qrb5165-rb5-*.img.gz)           |
-| [Release Notes](http://snapshots.linaro.org/96boards/qrb5165-rb5/linaro/debian/latest/)                                                |
+| [Desktop](http://releases.linaro.org/96boards/rb5/linaro/debian/latest/linaro-sid-gnome-qrb5165-rb5-*.img.gz)                      |
+| [Developer](http://releases.linaro.org/96boards/rb5/linaro/debian/latest/linaro-sid-developer-qrb5165-rb5-*.img.gz)           |
+| [Release Notes](http://releases.linaro.org/96boards/rb5/linaro/debian/latest/)                                                |
 
 #### Continue to [Installation page](../installation/)

--- a/consumer/dragonboard/qualcomm-robotics-rb5/downloads/open-embedded.md
+++ b/consumer/dragonboard/qualcomm-robotics-rb5/downloads/open-embedded.md
@@ -12,8 +12,8 @@ permalink: /documentation/consumer/dragonboard/qualcomm-robotics-rb5/downloads/o
 
 | Bootloader                                                                                                                             |
 |:---------------------------------------------------------------------------------------------------------------------------------------|
-| [Download](http://releases.linaro.org/96boards/rb5/linaro/rescue/21.04/rb5-bootloader-ufs-linux-*.zip)                                 |
-| [Release Notes](http://releases.linaro.org/96boards/rb5/linaro/rescue/21.04/)                                                          |
+| [Download](http://releases.linaro.org/96boards/rb5/linaro/rescue/latest/rb5-bootloader-ufs-linux-*.zip)                                 |
+| [Release Notes](http://releases.linaro.org/96boards/rb5/linaro/rescue/latest/)                                                          |
 
 Choose between RPB and RPB-Wayland. You will need to download the "boot image" and your choice of "Desktop" or "Console" rootfs.
 


### PR DESCRIPTION
Use 'latest' link instead of fixed (old) release.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>