### PR TITLE
developerbox: fix EDK2 build option

### DIFF
--- a/enterprise/developerbox/build/README.md
+++ b/enterprise/developerbox/build/README.md
@@ -143,7 +143,7 @@ unset ARCH
 . edk2/edksetup.sh
 make -C edk2/BaseTools
 
-build -p $ACTIVE_PLATFORM -b RELEASE -a AARCH64 -t GCC5 -n `nproc` -D DO_X86EMU=TRUE
+build -p $ACTIVE_PLATFORM -b RELEASE -a AARCH64 -t GCC5 -n `nproc` -D X64EMU_ENABLE=TRUE
 ~~~
 
 The firmware image, which comprises the option ROM, ARM trusted


### PR DESCRIPTION
DO_X86EMU is replaced with X64EMU_ENABLE, let's fix the
build procedure.

Signed-off-by: Masahisa Kojima <masahisa.kojima@linaro.org>