### PR TITLE
documentation/consumer: correct a Debian/Ubuntu method of installing fastboot

### DIFF
--- a/consumer/dragonboard/dragonboard410c/installation/linux-fastboot.md
+++ b/consumer/dragonboard/dragonboard410c/installation/linux-fastboot.md
@@ -38,10 +38,7 @@ This section show how to install a new operating system to your DragonBoard™ 4
   $ sudo yum install android-tools
 
   # Debian (Ubuntu)
-  $ sudo apt-get install android-tools
-
-  # Ubuntu 16.04 (Xenial) and beyond
-  $ sudo apt-get install android-tools-fastboot
+  $ sudo apt-get install fastboot
   ```
 
 #### **Step 2**: Connect host computer to DragonBoard 410c

--- a/consumer/dragonboard/dragonboard845c/installation/le.md
+++ b/consumer/dragonboard/dragonboard845c/installation/le.md
@@ -32,10 +32,7 @@ This section show how to install a new operating system to your DragonBoard™ 8
   $ sudo yum install android-tools
 
   # Debian (Ubuntu)
-  $ sudo apt-get install android-tools
-
-  # Ubuntu 16.04 (Xenial) and beyond
-  $ sudo apt-get install android-tools-fastboot
+  $ sudo apt-get install fastboot
   ```
 
 #### **Step 2**: Connect host computer to DragonBoard 845c

--- a/consumer/dragonboard/dragonboard845c/installation/linux-fastboot.md
+++ b/consumer/dragonboard/dragonboard845c/installation/linux-fastboot.md
@@ -35,10 +35,7 @@ This section show how to install a new operating system to your DragonBoard™ 8
   $ sudo yum install android-tools
 
   # Debian (Ubuntu)
-  $ sudo apt-get install android-tools
-
-  # Ubuntu 16.04 (Xenial) and beyond
-  $ sudo apt-get install android-tools-fastboot
+  $ sudo apt-get install fastboot
   ```
 
 #### **Step 2**: Connect host computer to RB3

--- a/consumer/dragonboard/qualcomm-robotics-rb1/installation/linux-fastboot.md
+++ b/consumer/dragonboard/qualcomm-robotics-rb1/installation/linux-fastboot.md
@@ -34,10 +34,7 @@ This section show how to install a new operating system to your Qualcomm Robotic
   $ sudo yum install android-tools
 
   # Debian (Ubuntu)
-  $ sudo apt-get install google-android-platform-tools-installer
-
-  # Ubuntu 16.04 (Xenial) and beyond
-  $ sudo apt-get install android-tools-fastboot
+  $ sudo apt-get install fastboot
   ```
 
 #### **Step 2**: Connect host computer to RB1

--- a/consumer/dragonboard/qualcomm-robotics-rb2/installation/linux-fastboot.md
+++ b/consumer/dragonboard/qualcomm-robotics-rb2/installation/linux-fastboot.md
@@ -34,10 +34,7 @@ This section show how to install a new operating system to your Qualcomm Robotic
   $ sudo yum install android-tools
 
   # Debian (Ubuntu)
-  $ sudo apt-get install google-android-platform-tools-installer
-
-  # Ubuntu 16.04 (Xenial) and beyond
-  $ sudo apt-get install android-tools-fastboot
+  $ sudo apt-get install fastboot
   ```
 
 #### **Step 2**: Connect host computer to RB2

--- a/consumer/dragonboard/qualcomm-robotics-rb5/installation/le.md
+++ b/consumer/dragonboard/qualcomm-robotics-rb5/installation/le.md
@@ -32,10 +32,7 @@ This section show how to install a new operating system to your Qualcomm Robotic
   $ sudo yum install android-tools
 
   # Debian (Ubuntu)
-  $ sudo apt-get install android-tools
-
-  # Ubuntu 16.04 (Xenial) and beyond
-  $ sudo apt-get install android-tools-fastboot
+  $ sudo apt-get install fastboot
   ```
 
 #### **Step 2**: Connect host computer to Qualcomm Robotics RB5 development kit

--- a/consumer/dragonboard/qualcomm-robotics-rb5/installation/linux-fastboot.md
+++ b/consumer/dragonboard/qualcomm-robotics-rb5/installation/linux-fastboot.md
@@ -35,10 +35,7 @@ This section show how to install a new operating system to your Qualcomm Robotic
   $ sudo yum install android-tools
 
   # Debian (Ubuntu)
-  $ sudo apt-get install android-tools
-
-  # Ubuntu 16.04 (Xenial) and beyond
-  $ sudo apt-get install android-tools-fastboot
+  $ sudo apt-get install fastboot
   ```
 
 #### **Step 2**: Connect host computer to RB5


### PR DESCRIPTION
The change unifies fastboot utility installation on Debian/Ubuntu over all consumer edition boards.