### PR TITLE
dragonboard 410c qdl lower chunk size

### DIFF
--- a/consumer/dragonboard/dragonboard410c/installation/board-recovery.md
+++ b/consumer/dragonboard/dragonboard410c/installation/board-recovery.md
@@ -46,7 +46,7 @@ http://snapshots.linaro.org/96boards/dragonboard410c/linaro/rescue/latest/dragon
 Then run:
 
     cd dragonboard-410c-bootloader-emmc-linux-*/
-    sudo <PATH to qdl>/qdl prog_emmc_firehose_8916.mbn rawprogram*.xml patch*.xml
+    sudo <PATH to qdl>/qdl --out-chunk-size 4096 prog_emmc_firehose_8916.mbn rawprogram*.xml patch*.xml
 
 It should take a few seconds. And you should eventually get something like below
 from QDL stdout:


### PR DESCRIPTION
This prevents the error "Host's payload to target size is too large"